### PR TITLE
Projective plane

### DIFF
--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -17,39 +17,3 @@ lemma card_finset_three {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
 
 
 end Finset
-
-namespace Set
-variable {α : Type*}
-
-lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A', B', C'})
-    (h₁ : A' ≠ B' ∧ A' ≠ C' ∧ B' ≠ C') : T ⊆ {A, B, C, D} → (T = {A, B, C}) ∨
-    (T = {A, B, D}) ∨ (T = {A, C, D}) ∨ (T = {B, C, D}) := by
-  subst T
-  obtain ⟨_, _, _⟩ := h₁
-  intro h₂
-  have := Set.subset_def.mp h₂
-  simp at this
-  rcases this with ⟨(rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl)⟩
-  any_goals
-    first
-    | contradiction
-    | simp
-  any_goals
-    first
-    | right; right; right; ext x; simp; tauto
-    | right; right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · right; left; ext x
-    simp [or_left_comm, or_comm, or_assoc]
-
-
-
-end Set

--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -34,26 +34,35 @@ lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A
     first
     | contradiction
     | simp
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · right; right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext y; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · right; right; right; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; right; right; ext x; simp; tauto
-  · right; right; left; ext y; simp; tauto
-  · right; right; right; ext z; simp; tauto
-  · right; left; ext x; simp; tauto
-  · right; right; left; ext y; simp; tauto
-  · right; left; ext z; simp; tauto
-  · right; right; right; ext w; simp; tauto
-  · right; right; left; ext y; simp; tauto
-  · right; right; right; ext z; simp; tauto
+  any_goals
+    first
+    | right; right; right; ext x; simp; tauto
+    | right; right; left; ext x; simp; tauto
+
+    -- | right; left; ext x; simp; tauto
+    -- | left; ext x; simp; tauto
+    -- | exfalso; contradiction
+  -- | right; left; ext x; simp; tauto
+  -- · left; ext x; simp; tauto
+  -- · right; left; ext x; simp; tauto
+  -- · right; right; left; ext x; simp; tauto
+  -- · left; ext x; simp; tauto
+  -- · right; left; ext y; simp; tauto
+  -- · left; ext x; simp; tauto
+  -- · right; left; ext x; simp; tauto
+  -- · right; right; right; ext x; simp; tauto
+  -- · left; ext x; simp; tauto
+  -- · right; right; left; ext x; simp; tauto
+  -- · left; ext x; simp; tauto
+  -- · right; right; right; ext x; simp; tauto
+  -- · right; right; left; ext y; simp; tauto
+  -- · right; right; right; ext x; simp; tauto
+  -- · right; left; ext x; simp; tauto
+  -- · right; right; left; ext y; simp; tauto
+  -- · right; left; ext z; simp; tauto
+  -- · right; right; right; ext w; simp; tauto
+  -- · right; right; left; ext x; simp; tauto
+  -- · right; right; right; ext z; simp; tauto
 
 
 end Set

--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -1,0 +1,21 @@
+import Mathlib.Data.Finset.Defs
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+
+
+namespace Finset
+open Finset
+variable {α : Type*} [Fintype α] [DecidableEq α]
+theorem mem_compl_singleton {a b : α} : a ∈ ({b}ᶜ : Finset α) ↔ a ≠ b := by
+  simp only [mem_compl, mem_singleton, ne_eq]
+
+lemma card_finset_three {α : Type*} [DecidableEq α] {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
+    (hBC : B ≠ C) : #{A, B, C} = 3 := by
+  rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
+  · show B ∉ {C}
+    simp [hBC]
+  · show  A ∉ {B, C}
+    simp [hAB, hAC]
+
+end Finset

--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -6,13 +6,54 @@ import Mathlib.Data.Fintype.Basic
 
 namespace Finset
 open Finset
-variable {α : Type*} [Fintype α] [DecidableEq α]
-theorem mem_compl_singleton {a b : α} : a ∈ ({b}ᶜ : Finset α) ↔ a ≠ b := by
+variable {α : Type*} [DecidableEq α]
+theorem mem_compl_singleton {a b : α} [Fintype α] : a ∈ ({b}ᶜ : Finset α) ↔ a ≠ b := by
   simp only [mem_compl, mem_singleton, ne_eq]
 
-lemma card_finset_three {α : Type*} [DecidableEq α] {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
+lemma card_finset_three {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
     (hBC : B ≠ C) : #{A, B, C} = 3 := by
   rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
   repeat simp [hBC, hAB, hAC]
 
+
 end Finset
+
+namespace Set
+variable {α : Type*}
+
+lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A', B', C'})
+    (h₁ : A' ≠ B' ∧ A' ≠ C' ∧ B' ≠ C') : T ⊆ {A, B, C, D} → (T = {A, B, C}) ∨
+    (T = {A, B, D}) ∨ (T = {A, C, D}) ∨ (T = {B, C, D}) := by
+  subst T
+  obtain ⟨_, _, _⟩ := h₁
+  intro h₂
+  have := Set.subset_def.mp h₂
+  simp at this
+  rcases this with ⟨(rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl)⟩
+  any_goals
+    first
+    | contradiction
+    | simp
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · right; right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext y; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · right; right; right; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; right; right; ext x; simp; tauto
+  · right; right; left; ext y; simp; tauto
+  · right; right; right; ext z; simp; tauto
+  · right; left; ext x; simp; tauto
+  · right; right; left; ext y; simp; tauto
+  · right; left; ext z; simp; tauto
+  · right; right; right; ext w; simp; tauto
+  · right; right; left; ext y; simp; tauto
+  · right; right; right; ext z; simp; tauto
+
+
+end Set

--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -38,31 +38,18 @@ lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A
     first
     | right; right; right; ext x; simp; tauto
     | right; right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · right; left; ext x
+    simp [or_left_comm, or_comm, or_assoc]
 
-    -- | right; left; ext x; simp; tauto
-    -- | left; ext x; simp; tauto
-    -- | exfalso; contradiction
-  -- | right; left; ext x; simp; tauto
-  -- · left; ext x; simp; tauto
-  -- · right; left; ext x; simp; tauto
-  -- · right; right; left; ext x; simp; tauto
-  -- · left; ext x; simp; tauto
-  -- · right; left; ext y; simp; tauto
-  -- · left; ext x; simp; tauto
-  -- · right; left; ext x; simp; tauto
-  -- · right; right; right; ext x; simp; tauto
-  -- · left; ext x; simp; tauto
-  -- · right; right; left; ext x; simp; tauto
-  -- · left; ext x; simp; tauto
-  -- · right; right; right; ext x; simp; tauto
-  -- · right; right; left; ext y; simp; tauto
-  -- · right; right; right; ext x; simp; tauto
-  -- · right; left; ext x; simp; tauto
-  -- · right; right; left; ext y; simp; tauto
-  -- · right; left; ext z; simp; tauto
-  -- · right; right; right; ext w; simp; tauto
-  -- · right; right; left; ext x; simp; tauto
-  -- · right; right; right; ext z; simp; tauto
 
 
 end Set

--- a/FiniteGeometry/Finset.lean
+++ b/FiniteGeometry/Finset.lean
@@ -13,9 +13,6 @@ theorem mem_compl_singleton {a b : α} : a ∈ ({b}ᶜ : Finset α) ↔ a ≠ b 
 lemma card_finset_three {α : Type*} [DecidableEq α] {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
     (hBC : B ≠ C) : #{A, B, C} = 3 := by
   rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
-  · show B ∉ {C}
-    simp [hBC]
-  · show  A ∉ {B, C}
-    simp [hAB, hAC]
+  repeat simp [hBC, hAB, hAC]
 
 end Finset

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -120,9 +120,13 @@ end ExtraDefinitions
 
 section BasicLemmas
 open Finset
-variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B : G.Point}
+variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B C : G.Point}
 
-lemma generalPosition_spec [DecidableEq G.Point]
+
+section DecidablePoint
+variable [DecidableEq G.Point]
+
+lemma generalPosition_spec
     (S : Set G.Point) (A B C : G.Point) (hA : A ∈ S) (hB : B ∈ S)
     (hC : C ∈ S) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C) :
     generalPosition S → ¬ collinear ({A, B, C} : Set G.Point) := by
@@ -137,46 +141,43 @@ lemma generalPosition_spec [DecidableEq G.Point]
     exact card_finset_three hAB hAC hBC
 
 
-lemma quad_rule (A B C D : G.Point) :
-  quad A B C D ↔
-  ¬collinear {A, B, C} ∧ ¬collinear {A, B, D} ∧ ¬collinear {A, C, D} ∧ ¬collinear {B, C, D} := by sorry
-  -- constructor
-  -- · rintro ⟨h, H⟩
-  --   unfold generalPosition at H
-  --   refine ⟨?_, ?_, ?_, ?_⟩
-  --   let S : Set G.Point := ({A,B,C,D} : Set G.Point)
-  --   have hsub : ↑({A,B,C} : Finset G.Point) ⊆ S := by
-  --       intro x hx
-  --       have : x = A ∨ x = B ∨ x = C := by simpa using hx
-  --       -- simp [S]
-  --       rcases this with (rfl | rfl | rfl) <;> simp [S]
-  --   subst S
-  --   have hcard : ({A,B,C} : Finset G.Point).card = 3 := by aesop
-  --   exact_mod_cast h ({A, B, C}) hsub hcard
-  --   have hcard := card_finset_three (G := G) h.AB h.AC h.BC
-  --   exact H ({A,B,C}) hsub hcard
-  --   have h1 : ({A B C} : Finset G.Point) ⊆ {A, B, C, D} := by
-  --   simp only [Finset.subset_iff, Finset.mem_insert, Finset.mem_singleton]
-  --   intro x hx
-  --   cases' hx with hx hx
-  --   · left; exact hx
-  --   · cases' hx with hx hx
-  --     · right; left; exact hx
-  --     · right; right; left; exact hx
-  -- have h2 : ({A, B, C} : Finset G.Point).card = 3 := by simp [Finset.card_insert_of_not_mem]
-  -- exact (h {A, B, C} (by exact_mod_cast h1) h2).2
-  --   specialize h {A, B, C}
-  --   simp at h
-  --   exact ⟨h.2, by
-  --     specialize h {A, B, D}
-  --     simp at h
-  --     exact h.2, by
-  --     specialize h {A, C, D}
-  --     simp at h
-  --     exact h.2, by
-  --     specialize h {B, C, D}
-  --     simp at h
-  --     exact h.2⟩
+lemma quad_rule {A B C D : G.Point} :
+    quad A B C D ↔
+    (A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D) ∧
+    ¬collinear {A, B, C} ∧ ¬collinear {A, B, D} ∧ ¬collinear {A, C, D} ∧ ¬collinear {B, C, D} := by
+  constructor
+  · rintro ⟨h, H⟩
+    have ⟨h₁, h₂, h₃, h₄, h₅, h₆⟩ := h
+    refine ⟨h, ⟨?_, ?_, ?_, ?_⟩⟩
+    all_goals
+      apply generalPosition_spec (S := {A, B, C, D})
+      · simp
+      · simp
+      · simp
+      · assumption
+      · assumption
+      · assumption
+      · assumption
+  · rintro ⟨h, ⟨h₁, h₂, h₃, h₄⟩⟩
+    constructor
+    · show A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D
+      exact h
+    · show generalPosition {A, B, C, D}
+      simp [generalPosition]
+      intro T hTsub hTcard
+      have : T = {A, B, C} ∨ T = {A, B, D} ∨ T = {A, C, D} ∨ T = {B, C, D} := sorry
+      rcases this with rfl | rfl | rfl | rfl
+      · suffices h: ¬ collinear {A, B, C} by simpa using h
+        assumption
+      · suffices h: ¬ collinear {A, B, D} by simpa using h
+        assumption
+      · suffices h: ¬ collinear {A, C, D} by simpa using h
+        assumption
+      · suffices h: ¬ collinear {B, C, D} by simpa using h
+        assumption
+
+
+end DecidablePoint
 
 lemma line_ne_of_mem_not_mem (hAℓ : A ∈ᵢ ℓ) (hAnotm : ¬ A ∈ᵢ m) : ℓ ≠ m := by
   rintro rfl; contradiction

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -5,6 +5,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import FiniteGeometry.Finset
+import FiniteGeometry.Set
 
 
 structure IncidenceGeometry where

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -114,4 +114,14 @@ end Subgeometry
 
 end ExtraDefinitions
 
+section BasicLemmas
+variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B : G.Point}
+
+lemma line_ne_of_mem_not_mem (hAℓ : A ∈ᵢ ℓ) (hAnotm : ¬ A ∈ᵢ m) : ℓ ≠ m := by
+  rintro rfl; contradiction
+
+lemma point_ne_of_mem_not_mem (hAnot : ¬ A ∈ᵢ ℓ) (hB : B ∈ᵢ ℓ) : A ≠ B := by
+  rintro rfl; contradiction
+end BasicLemmas
+
 end IncidenceGeometry

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -15,6 +15,10 @@ namespace IncidenceGeometry
 
 variable {G : IncidenceGeometry}
 
+@[inline] def inc {G : IncidenceGeometry} : G.Point → G.Line → Prop :=
+  G.incidence
+
+scoped infix:50 " ∈ᵢ " => IncidenceGeometry.inc
 
 
 @[simp]
@@ -93,11 +97,12 @@ structure Subgeometry (G : IncidenceGeometry) where
   LineSub  : Set G.Line
 
 namespace Subgeometry
+variable {G: IncidenceGeometry}
 
-def incidence {G : IncidenceGeometry} (H : Subgeometry G)
+def incidence (H : Subgeometry G)
     (p : { q : G.Point // q ∈ H.PointSub })
     (ℓ : { m : G.Line  // m ∈ H.LineSub }) : Prop :=
-  G.incidence p.val ℓ.val
+  p.val ∈ᵢ ℓ.val
 
 def toIncidenceGeometry {G : IncidenceGeometry} (H : Subgeometry G) : IncidenceGeometry :=
 { Point          := { p : G.Point // p ∈ H.PointSub }

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -122,7 +122,6 @@ section BasicLemmas
 open Finset
 variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B : G.Point}
 
-
 lemma generalPosition_spec [DecidableEq G.Point]
     (S : Set G.Point) (A B C : G.Point) (hA : A ∈ S) (hB : B ∈ S)
     (hC : C ∈ S) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C) :
@@ -132,18 +131,8 @@ lemma generalPosition_spec [DecidableEq G.Point]
   suffices h: ¬collinear (T : Set G.Point) by simpa [hT] using h
   apply hGP T
   · show (T : Set G.Point) ⊆ S
-    intro x hx
-    have hx₁ := Finset.mem_insert.mp hx
-    cases hx₁ with
-    | inl hxA => rw [hxA]; assumption
-    | inr hx' =>
-        have hx₂ := Finset.mem_insert.mp hx'
-        cases hx₂ with
-        | inl hxB =>
-            rw [hxB]; assumption
-        | inr hxC' =>
-            have hxC : x = C := Finset.mem_singleton.mp hxC'
-            rw [hxC]; assumption
+    subst T; simp
+    apply Set.insert_subset hA; apply Set.insert_subset hB; apply Set.singleton_subset_iff.mpr hC
   · show #T = 3
     exact card_finset_three hAB hAC hBC
 

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -10,21 +10,18 @@ structure IncidenceGeometry where
   Point : Type*
   Line : Type*
   incidence : Point → Line → Prop
-  [point_fintype : Fintype Point]
-  [line_fintype : Fintype Line]
 
 namespace IncidenceGeometry
 
 variable {G : IncidenceGeometry}
-instance : Fintype G.Point := G.point_fintype
-instance : Fintype G.Line := G.line_fintype
 
 
-@[simp]
-def trace (ℓ : G.Line) :=  { p : G.Point // G.incidence p ℓ }
 
 @[simp]
-def pencil (p : G.Point) :=  { ℓ : G.Line // G.incidence p ℓ }
+def trace (ℓ : G.Line) : Set G.Point := { p | G.incidence p ℓ }
+
+@[simp]
+def pencil (p : G.Point) : Set G.Line :=  { ℓ : G.Line | G.incidence p ℓ }
 
 
 section Category
@@ -69,10 +66,47 @@ def dual (G : IncidenceGeometry) : IncidenceGeometry where
   Point := G.Line
   Line := G.Point
   incidence := fun l p ↦ G.incidence p l
-  point_fintype := G.line_fintype
-  line_fintype := G.point_fintype
+
 
 
 end Category
+
+section ExtraDefinitions
+
+variable {G : IncidenceGeometry}
+
+def collinear (S : Set G.Point) : Prop :=
+  ∃ ℓ : G.Line, S ⊆ (trace ℓ : Set G.Point)
+
+def triangle (T : Finset G.Point) : Prop :=
+  T.card = 3 ∧ ¬ collinear (T : Set G.Point)
+
+def generalPosition (S : Set G.Point) : Prop :=
+  ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → triangle T
+
+def concurrent (L : Set G.Line) : Prop :=
+  ∃ p : G.Point, L ⊆ (pencil p : Set G.Line)
+
+
+structure Subgeometry (G : IncidenceGeometry) where
+  PointSub : Set G.Point
+  LineSub  : Set G.Line
+
+namespace Subgeometry
+
+def incidence {G : IncidenceGeometry} (H : Subgeometry G)
+    (p : { q : G.Point // q ∈ H.PointSub })
+    (ℓ : { m : G.Line  // m ∈ H.LineSub }) : Prop :=
+  G.incidence p.val ℓ.val
+
+def toIncidenceGeometry {G : IncidenceGeometry} (H : Subgeometry G) : IncidenceGeometry :=
+{ Point          := { p : G.Point // p ∈ H.PointSub }
+  Line           := { ℓ : G.Line  // ℓ ∈ H.LineSub }
+  incidence      := H.incidence
+}
+
+end Subgeometry
+
+end ExtraDefinitions
 
 end IncidenceGeometry

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Finset.Defs
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
+import FiniteGeometry.Finset
 
 
 structure IncidenceGeometry where
@@ -118,20 +119,11 @@ end Subgeometry
 end ExtraDefinitions
 
 section BasicLemmas
-open scoped Finset
-variable {G : IncidenceGeometry} [DecidableEq G.Point] {ℓ m : G.Line} {A B : G.Point}
+open Finset
+variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B : G.Point}
 
-open scoped Finset
 
-lemma card_finset_three {α : Type*} [DecidableEq α] {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
-    (hBC : B ≠ C) : #({A, B, C} : Finset α) = 3 := by
-  rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
-  · show B ∉ {C}
-    simp [hBC]
-  · show  A ∉ {B, C}
-    simp [hAB, hAC]
-
-lemma generalPosition_spec
+lemma generalPosition_spec [DecidableEq G.Point]
     (S : Set G.Point) (A B C : G.Point) (hA : A ∈ S) (hB : B ∈ S)
     (hC : C ∈ S) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C) :
     generalPosition S → ¬ collinear ({A, B, C} : Set G.Point) := by

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -87,7 +87,8 @@ def triangle (T : Finset G.Point) : Prop :=
   T.card = 3 ∧ ¬ collinear (T : Set G.Point)
 
 def generalPosition (S : Set G.Point) : Prop :=
-  ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → ¬ collinear (T : Set G.Point)
+  ∀ A B C : G.Point, {A, B, C} ⊆ S ∧ (A ≠ B ∧ A ≠ C ∧ B ≠ C) → ¬ collinear {A, B, C}
+  -- ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → ¬ collinear (T : Set G.Point)
 
 def concurrent (L : Set G.Line) : Prop :=
   ∃ p : G.Point, L ⊆ (pencil p : Set G.Line)
@@ -124,21 +125,20 @@ variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B C : G.Point}
 
 
 section DecidablePoint
-variable [DecidableEq G.Point]
 
 lemma generalPosition_spec
     (S : Set G.Point) (A B C : G.Point) (hA : A ∈ S) (hB : B ∈ S)
     (hC : C ∈ S) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C) :
     generalPosition S → ¬ collinear ({A, B, C} : Set G.Point) := by
   intro hGP
-  set T : Finset G.Point := {A, B, C} with hT
-  suffices h: ¬collinear (T : Set G.Point) by simpa [hT] using h
-  apply hGP T
-  · show (T : Set G.Point) ⊆ S
-    subst T; simp
+  specialize hGP A B C
+  apply hGP
+  constructor
+  · show {A, B, C} ⊆ S
     apply Set.insert_subset hA; apply Set.insert_subset hB; apply Set.singleton_subset_iff.mpr hC
-  · show #T = 3
-    exact card_finset_three hAB hAC hBC
+  · show (A ≠ B ∧ A ≠ C ∧ B ≠ C)
+    exact ⟨hAB, hAC, hBC⟩
+
 
 
 lemma quad_rule {A B C D : G.Point} :
@@ -163,18 +163,13 @@ lemma quad_rule {A B C D : G.Point} :
     · show A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D
       exact h
     · show generalPosition {A, B, C, D}
-      simp [generalPosition]
-      intro T hTsub hTcard
-      have : T = {A, B, C} ∨ T = {A, B, D} ∨ T = {A, C, D} ∨ T = {B, C, D} := sorry
-      rcases this with rfl | rfl | rfl | rfl
-      · suffices h: ¬ collinear {A, B, C} by simpa using h
-        assumption
-      · suffices h: ¬ collinear {A, B, D} by simpa using h
-        assumption
-      · suffices h: ¬ collinear {A, C, D} by simpa using h
-        assumption
-      · suffices h: ¬ collinear {B, C, D} by simpa using h
-        assumption
+      simp only [generalPosition]
+      intro A' B' C'
+      rintro ⟨hl, hr⟩
+      set T := ({A', B', C'} : Set G.Point) with hT
+      rcases (Set.subset_four_choose_three (h:=hT) hr hl) with (h|h|h|h)
+      all_goals
+      · rw [h] at *; assumption
 
 
 end DecidablePoint

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -88,15 +88,13 @@ def triangle (T : Finset G.Point) : Prop :=
   T.card = 3 ∧ ¬ collinear (T : Set G.Point)
 
 def generalPosition (S : Set G.Point) : Prop :=
-  ∀ A B C : G.Point, {A, B, C} ⊆ S ∧ (A ≠ B ∧ A ≠ C ∧ B ≠ C) → ¬ collinear {A, B, C}
-  -- ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → ¬ collinear (T : Set G.Point)
+  ∀ A B C, {A, B, C} ⊆ S ∧ (A ≠ B ∧ A ≠ C ∧ B ≠ C) → ¬ collinear {A, B, C}
 
 def concurrent (L : Set G.Line) : Prop :=
   ∃ p : G.Point, L ⊆ (pencil p : Set G.Line)
 
 def quad (A B C D : G.Point) : Prop :=
-  (A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D) ∧
-  generalPosition {A, B, C, D}
+  (A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D) ∧ generalPosition {A, B, C, D}
 
 structure Subgeometry (G : IncidenceGeometry) where
   PointSub : Set G.Point

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -151,13 +151,9 @@ lemma quad_rule {A B C D : G.Point} :
     refine ⟨h, ⟨?_, ?_, ?_, ?_⟩⟩
     all_goals
       apply generalPosition_spec (S := {A, B, C, D})
-      · simp
-      · simp
-      · simp
-      · assumption
-      · assumption
-      · assumption
-      · assumption
+      <;> try simp
+    all_goals
+      assumption
   · rintro ⟨h, ⟨h₁, h₂, h₃, h₄⟩⟩
     constructor
     · show A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -129,8 +129,9 @@ lemma generalPosition_spec [DecidableEq G.Point]
     generalPosition S → ¬ collinear ({A, B, C} : Set G.Point) := by
   intro hGP
   set T : Finset G.Point := {A, B, C} with hT
-  have : #T = 3 := card_finset_three hAB hAC hBC
-  have hSub : (T : Set G.Point) ⊆ S := by
+  suffices h: ¬collinear (T : Set G.Point) by simpa [hT] using h
+  apply hGP T
+  · show (T : Set G.Point) ⊆ S
     intro x hx
     have hx₁ := Finset.mem_insert.mp hx
     cases hx₁ with
@@ -143,11 +144,9 @@ lemma generalPosition_spec [DecidableEq G.Point]
         | inr hxC' =>
             have hxC : x = C := Finset.mem_singleton.mp hxC'
             rw [hxC]; assumption
+  · show #T = 3
+    exact card_finset_three hAB hAC hBC
 
-
-  have : ¬ collinear (T : Set G.Point) :=
-    hGP T hSub this
-  simpa [hT] using this
 
 lemma quad_rule (A B C D : G.Point) :
   quad A B C D ↔

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -86,11 +86,14 @@ def triangle (T : Finset G.Point) : Prop :=
   T.card = 3 ∧ ¬ collinear (T : Set G.Point)
 
 def generalPosition (S : Set G.Point) : Prop :=
-  ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → triangle T
+  ∀ T : Finset G.Point, (T : Set G.Point) ⊆ S → T.card = 3 → ¬ collinear (T : Set G.Point)
 
 def concurrent (L : Set G.Line) : Prop :=
   ∃ p : G.Point, L ⊆ (pencil p : Set G.Line)
 
+def quad (A B C D : G.Point) : Prop :=
+  (A ≠ B ∧ A ≠ C ∧ A ≠ D ∧ B ≠ C ∧ B ≠ D ∧ C ≠ D) ∧
+  generalPosition {A, B, C, D}
 
 structure Subgeometry (G : IncidenceGeometry) where
   PointSub : Set G.Point
@@ -115,7 +118,85 @@ end Subgeometry
 end ExtraDefinitions
 
 section BasicLemmas
-variable {G : IncidenceGeometry} {ℓ m : G.Line} {A B : G.Point}
+open scoped Finset
+variable {G : IncidenceGeometry} [DecidableEq G.Point] {ℓ m : G.Line} {A B : G.Point}
+
+open scoped Finset
+
+lemma card_finset_three {α : Type*} [DecidableEq α] {A B C : α} (hAB : A ≠ B) (hAC : A ≠ C)
+    (hBC : B ≠ C) : #({A, B, C} : Finset α) = 3 := by
+  rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
+  · show B ∉ {C}
+    simp [hBC]
+  · show  A ∉ {B, C}
+    simp [hAB, hAC]
+
+lemma generalPosition_spec
+    (S : Set G.Point) (A B C : G.Point) (hA : A ∈ S) (hB : B ∈ S)
+    (hC : C ∈ S) (hAB : A ≠ B) (hAC : A ≠ C) (hBC : B ≠ C) :
+    generalPosition S → ¬ collinear ({A, B, C} : Set G.Point) := by
+  intro hGP
+  set T : Finset G.Point := {A, B, C} with hT
+  have : #T = 3 := card_finset_three hAB hAC hBC
+  have hSub : (T : Set G.Point) ⊆ S := by
+    intro x hx
+    have hx₁ := Finset.mem_insert.mp hx
+    cases hx₁ with
+    | inl hxA => rw [hxA]; assumption
+    | inr hx' =>
+        have hx₂ := Finset.mem_insert.mp hx'
+        cases hx₂ with
+        | inl hxB =>
+            rw [hxB]; assumption
+        | inr hxC' =>
+            have hxC : x = C := Finset.mem_singleton.mp hxC'
+            rw [hxC]; assumption
+
+
+  have : ¬ collinear (T : Set G.Point) :=
+    hGP T hSub this
+  simpa [hT] using this
+
+lemma quad_rule (A B C D : G.Point) :
+  quad A B C D ↔
+  ¬collinear {A, B, C} ∧ ¬collinear {A, B, D} ∧ ¬collinear {A, C, D} ∧ ¬collinear {B, C, D} := by sorry
+  -- constructor
+  -- · rintro ⟨h, H⟩
+  --   unfold generalPosition at H
+  --   refine ⟨?_, ?_, ?_, ?_⟩
+  --   let S : Set G.Point := ({A,B,C,D} : Set G.Point)
+  --   have hsub : ↑({A,B,C} : Finset G.Point) ⊆ S := by
+  --       intro x hx
+  --       have : x = A ∨ x = B ∨ x = C := by simpa using hx
+  --       -- simp [S]
+  --       rcases this with (rfl | rfl | rfl) <;> simp [S]
+  --   subst S
+  --   have hcard : ({A,B,C} : Finset G.Point).card = 3 := by aesop
+  --   exact_mod_cast h ({A, B, C}) hsub hcard
+  --   have hcard := card_finset_three (G := G) h.AB h.AC h.BC
+  --   exact H ({A,B,C}) hsub hcard
+  --   have h1 : ({A B C} : Finset G.Point) ⊆ {A, B, C, D} := by
+  --   simp only [Finset.subset_iff, Finset.mem_insert, Finset.mem_singleton]
+  --   intro x hx
+  --   cases' hx with hx hx
+  --   · left; exact hx
+  --   · cases' hx with hx hx
+  --     · right; left; exact hx
+  --     · right; right; left; exact hx
+  -- have h2 : ({A, B, C} : Finset G.Point).card = 3 := by simp [Finset.card_insert_of_not_mem]
+  -- exact (h {A, B, C} (by exact_mod_cast h1) h2).2
+  --   specialize h {A, B, C}
+  --   simp at h
+  --   exact ⟨h.2, by
+  --     specialize h {A, B, D}
+  --     simp at h
+  --     exact h.2, by
+  --     specialize h {A, C, D}
+  --     simp at h
+  --     exact h.2, by
+  --     specialize h {B, C, D}
+  --     simp at h
+  --     exact h.2⟩
 
 lemma line_ne_of_mem_not_mem (hAℓ : A ∈ᵢ ℓ) (hAnotm : ¬ A ∈ᵢ m) : ℓ ≠ m := by
   rintro rfl; contradiction

--- a/FiniteGeometry/IncidenceGeometry.lean
+++ b/FiniteGeometry/IncidenceGeometry.lean
@@ -132,11 +132,7 @@ lemma generalPosition_spec
   intro hGP
   specialize hGP A B C
   apply hGP
-  constructor
-  · show {A, B, C} ⊆ S
-    apply Set.insert_subset hA; apply Set.insert_subset hB; apply Set.singleton_subset_iff.mpr hC
-  · show (A ≠ B ∧ A ≠ C ∧ B ≠ C)
-    exact ⟨hAB, hAC, hBC⟩
+  simp [Set.subset_def]; tauto
 
 
 

--- a/FiniteGeometry/IncidenceGeometryExamples.lean
+++ b/FiniteGeometry/IncidenceGeometryExamples.lean
@@ -1,12 +1,7 @@
 import FiniteGeometry.IncidenceGeometry
 
 
-namespace Finset
-open Finset
-variable {α : Type*} [Fintype α] [DecidableEq α]
-theorem mem_compl_singleton {a b : α} : a ∈ ({b}ᶜ : Finset α) ↔ a ≠ b := by
-  simp only [mem_compl, mem_singleton, ne_eq]
-end Finset
+
 
 section Examples
 -- To avoid linter warnings when simpa is applied to many goals
@@ -94,10 +89,7 @@ lemma exists_unique_disjoint_line (p : affineAG22.Point) (b :affineAG22.Line) (h
   let known_points : Finset affineAG22.Point := {p, q₁, q₂}
   let remaining := (univ : Finset affineAG22.Point) \ known_points
   have h_remaining_card : #remaining = 1 := by
-    have h_known_card : #known_points = 3 :=
-      IncidenceGeometry.card_finset_three
-        (α := affineAG22.Point) (A := p) (B := q₁) (C := q₂)
-        p_ne_q₁ p_ne_q₂ h_neq
+    have h_known_card : #known_points = 3 := card_finset_three p_ne_q₁ p_ne_q₂ h_neq
     have h_univ_card : #(Finset.univ : Finset affineAG22.Point) = 4 := by rfl
     simp [remaining, Finset.card_sdiff, h_univ_card, h_known_card]
 

--- a/FiniteGeometry/IncidenceGeometryExamples.lean
+++ b/FiniteGeometry/IncidenceGeometryExamples.lean
@@ -94,11 +94,10 @@ lemma exists_unique_disjoint_line (p : affineAG22.Point) (b :affineAG22.Line) (h
   let known_points : Finset affineAG22.Point := {p, q₁, q₂}
   let remaining := (univ : Finset affineAG22.Point) \ known_points
   have h_remaining_card : #remaining = 1 := by
-    have h_known_card : #known_points = 3 := by
-      show #({p, q₁, q₂} : Finset affineAG22.Point) = 3
-      rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
-      · simp [h_neq]
-      · simp [p_ne_q₁, p_ne_q₂]
+    have h_known_card : #known_points = 3 :=
+      IncidenceGeometry.card_finset_three
+        (α := affineAG22.Point) (A := p) (B := q₁) (C := q₂)
+        p_ne_q₁ p_ne_q₂ h_neq
     have h_univ_card : #(Finset.univ : Finset affineAG22.Point) = 4 := by rfl
     simp [remaining, Finset.card_sdiff, h_univ_card, h_known_card]
 

--- a/FiniteGeometry/IncidenceGeometryExamples.lean
+++ b/FiniteGeometry/IncidenceGeometryExamples.lean
@@ -20,13 +20,25 @@ def steinerS335 : IncidenceGeometry where
 
 def affineAG22 : IncidenceGeometry where
   Point := Fin 4
-  Line := { s : Finset (Fin 4) // s.card = 2 }
+  Line := { s : Finset (Fin 4) // #s = 2 }
   incidence := fun p b ↦ p ∈ b.val
 
 
 namespace affineAG22Props
 
 namespace affineAG22
+
+def twoSubsets : Finset (Finset (Fin 4)) :=
+  (Finset.univ : Finset (Finset (Fin 4))).filter (fun s ↦ s.card = 2)
+
+lemma twoSubsets_spec :
+    ∀ s : Finset (Fin 4), s ∈ twoSubsets ↔ s.card = 2 := by
+  intro s
+  simp [twoSubsets]
+
+instance : Fintype affineAG22.Line := Fintype.subtype twoSubsets twoSubsets_spec
+instance : Fintype affineAG22.Point := inferInstanceAs (Fintype (Fin 4))
+
 def pencil (p : affineAG22.Point) : Finset affineAG22.Line := { l | p ∈ l.val }
 def trace (ℓ : affineAG22.Line) : Finset affineAG22.Point := ℓ.val
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -29,31 +29,6 @@ class ProjectivePlane (G : IncidenceGeometry) : Prop where
         ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
         G.incidence p ℓ ∧ G.incidence p m ∧ G.incidence p n
 
-namespace ProjectivePlane
-
-variable {G : IncidenceGeometry} [ProjectivePlane G]
-
-noncomputable
-def lineThrough {p q : G.Point} (h : p ≠ q) : G.Line :=
-  (P1 h).choose
-
-lemma lineThrough_incidence_left {p q : G.Point} (h : p ≠ q) : G.incidence p (lineThrough h) :=
-  (P1 h).choose_spec.1.1
-
-lemma lineThrough_incidence_right {p q : G.Point} (h : p ≠ q) : G.incidence q (lineThrough h) :=
-  (P1 h).choose_spec.1.2
-
-noncomputable
-def meet {ℓ m : G.Line} (h : ℓ ≠ m) : G.Point :=
-  (P2 h).choose
-
-lemma meet_incidence_left {ℓ m : G.Line} (h : ℓ ≠ m) : G.incidence (meet h) ℓ :=
-  (P2 h).choose_spec.1.1
-
-lemma meet_incidence_right {ℓ m : G.Line} (h : ℓ ≠ m) : G.incidence (meet h) m :=
-  (P2 h).choose_spec.1.2
-
-end ProjectivePlane
 
 instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : ProjectivePlane G.dual where
   P1 := ProjectivePlane.P2

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -396,20 +396,10 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
           P3 := three_points_on_line  hP1 hP2 hP3',
           P4 := three_lines_through_point hP1 hP2 hP3'}
     | inr hP3'' =>
-        -- The P₃″ branch is handled dually (mirror-symmetric argument),
-        -- left to the reader; `aesop` can discharge it automatically.
-        have hP3 : ∀ ℓ : G.Line, ∃ p q r : G.Point,
-            p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-            G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
-          aesop
-        have hP4 : ∀ p : G.Point, ∃ ℓ m n : G.Line,
-            ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
-            G.incidence p ℓ ∧ G.incidence p m ∧ G.incidence p n := by
-          aesop
         exact
         { P1 := hP1,
           P2 := hP2,
-          P3 := hP3,
-          P4 := hP4 }
+          P3 := three_points_on_line hP1 hP2 (P3'_of_P3'' hP1 hP2 hP3''),
+          P4 := three_lines_through_point hP1 hP2 (P3'_of_P3'' hP1 hP2 hP3'') }
 
 end AlternativeAxioms

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -17,7 +17,6 @@ end ProjectivePrereqs
 
 class ProjectivePlane (G : IncidenceGeometry) : Prop where
   P0 : Nonempty G.Point
-  P0' : Nonempty G.Line
   P1 : ProjectivePrereqs.P1 (G := G)
   P2 : ProjectivePrereqs.P2 (G := G)
   P3 :
@@ -31,10 +30,13 @@ class ProjectivePlane (G : IncidenceGeometry) : Prop where
         ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
         A ∈ᵢ ℓ ∧ A ∈ᵢ m ∧ A ∈ᵢ n
 
+theorem P0' {G : IncidenceGeometry} [ProjectivePlane G]: Nonempty G.Line := by
+  obtain ⟨O⟩ := ProjectivePlane.P0 (G := G)
+  rcases ProjectivePlane.P4 O with ⟨a, -⟩
+  use a
 
 instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : ProjectivePlane G.dual where
-  P0 := ProjectivePlane.P0'
-  P0' := ProjectivePlane.P0
+  P0 := P0'
   P1 := ProjectivePlane.P2
   P2 := ProjectivePlane.P1
   P3 := ProjectivePlane.P4
@@ -388,7 +390,6 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
     | inl hP3' =>
         exact
         { P0 := point_from_P3' hP3',
-          P0' := line_from_P1_P3' hP1 hP3',
           P1 := hP1,
           P2 := hP2,
           P3 := three_points_on_line  hP1 hP2 hP3',
@@ -397,7 +398,6 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
         have hP3' : P3' := P3'_of_P3'' hP1 hP2 hP3''
         exact
         { P0 := point_from_P3' hP3',
-          P0' := line_from_P1_P3' hP1 hP3',
           P1 := hP1,
           P2 := hP2,
           P3 := three_points_on_line hP1 hP2 hP3',

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -71,6 +71,16 @@ def triSet (a b c : G.Point) : Set G.Point :=
 def noncollinear (a b c : G.Point) : Prop :=
   ¬ IncidenceGeometry.collinear (triSet a b c)
 
+lemma noncollinear_incidence (ℓ : G.Line) :
+  noncollinear A B C → ¬G.incidence A ℓ ∧ ¬G.incidence B ℓ ∧ ¬G.incidence C ℓ := by
+  intro h
+  -- sorry
+  -- push_neg at h
+  -- rcases h with (hA | hB | hC)
+  -- · exact ⟨hA, hB, hC⟩
+  -- · exact ⟨hB, hC, hA⟩
+  -- · exact ⟨hC, hA, hB⟩
+
 lemma noncollinear_perm (a b c : G.Point) :
   noncollinear a b c ↔ noncollinear b c a ∧ noncollinear c a b := by
   simp only [noncollinear, collinear, triSet]
@@ -128,7 +138,8 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
      hAB,hAC,hAD,hBC,hBD,hCD,
      hABC,hABD,hACD,hBCD⟩
   wlog h_not_A : ¬ G.incidence A ℓ
-  · suffices h: ¬ G.incidence B ℓ ∨ ¬ G.incidence C ℓ by
+  · suffices h: ¬ (G.incidence B ℓ ∧ G.incidence C ℓ) by
+      have : ¬G.incidence B ℓ ∨ ¬ G.incidence C ℓ := by
       rcases h with (hB | hC)
       · have h_bad: noncollinear B A D := by
           simp [noncollinear]

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -91,6 +91,13 @@ lemma line_eq_of_point_eq
   · exact hℓ
   · exact hm.symm
 
+lemma point_eq_of_incident
+    (hP2 : P2 (G := G)) {ℓ m : G.Line} (hℓm : ℓ ≠ m)
+    {P Q : G.Point} (hPℓ : P ∈ᵢ ℓ) (hPm : P ∈ᵢ m)
+    (hQℓ : Q ∈ᵢ ℓ) (hQm : Q ∈ᵢ m) : P = Q :=
+  line_eq_of_point_eq (G := G.dual) (hP1 := hP2) (A := ℓ) (P := m) (ℓ := P) (m := Q)
+    hℓm hPℓ hPm hQℓ hQm
+
 lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
     (hABC : noncollinear A B C) (hA_ne_PB : A ≠ P) (hA_ne_P : A ≠ Q)
     {mB mC : G.Line}
@@ -102,8 +109,8 @@ lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
   simp [noncollinear, triSet, collinear] at hABC
   apply hABC mB <;> assumption
 
-lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G))
-    (hP3' : P3' (G := G)) :
+lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+    (ℓ : G.Line):
     ∃ p q r : G.Point,
       p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
       p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
@@ -149,10 +156,75 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
     apply points_distinct_of_noncollinear hP1 (P:=PC) (Q:=PD) (mB:=mC) (mC:=mD) hACD
     <;> assumption
 
+lemma P3'_dual_of_P3'
+    (hP1  : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G)) : P3' (G := G.dual) := by
+  rcases hP3' with
+    ⟨A, B, C, D,
+     hAB, hAC, hAD, hBC, hBD, hCD,
+     hABC, hABD, hACD, hBCD⟩
+
+  obtain ⟨ℓAB, hAℓAB, hBℓAB⟩ := hP1 hAB
+  obtain ⟨ℓAC, hAℓAC, hCℓAC⟩ := hP1 hAC
+  obtain ⟨ℓBD, hBℓBD, hDℓBD⟩ := hP1 hBD
+  obtain ⟨ℓCD, hCℓCD, hDℓCD⟩ := hP1 hCD
+
+  have ℓAB_ne_ℓAC : ℓAB ≠ ℓAC := by sorry
+  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := by sorry
+  have ℓAB_ne_ℓCD : ℓAB ≠ ℓCD := by sorry
+  have ℓBD_ne_ℓCD : ℓBD ≠ ℓCD := by sorry
+
+  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := sorry
+  have ℓAC_ne_ℓBD : ℓAC ≠ ℓBD := sorry
+  have ℓAC_ne_ℓCD : ℓAC ≠ ℓCD := sorry
+
+  refine
+    ⟨ℓAB, ℓAC, ℓBD, ℓCD,
+     ℓAB_ne_ℓAC, ℓAB_ne_ℓBD, ℓAB_ne_ℓCD,
+     ℓAC_ne_ℓBD, ℓAC_ne_ℓCD, ℓBD_ne_ℓCD,
+     ?nclℓABℓACℓBD, ?nclℓABℓACℓCD,
+     ?nclℓABℓBDℓCD, ?nclℓACℓBDℓCD⟩
+
+  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓBD by
+      simpa [noncollinear, collinear, triSet] using h_no_common
+    intro ⟨P, hPAB, hPAC, hPBD⟩
+    apply hAB
+    have hPA : P = A := point_eq_of_incident hP2 ℓAB_ne_ℓAC hPAB hPAC hAℓAB.1 hAℓAC.1
+    have hPB : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hAℓAB.2 hBℓBD.1
+    show A = B
+    trans P <;> (first | exact hPA.symm | exact hPB)
+
+  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓCD by
+      simpa [noncollinear, collinear, triSet] using h_no_common
+    intro ⟨P, hPAB, hPAC, hPCD⟩
+    apply hAC
+    have hPA : P = A := point_eq_of_incident hP2 ℓAB_ne_ℓAC hPAB hPAC hAℓAB.1 hAℓAC.1
+    have hPB : P = C := point_eq_of_incident hP2 ℓAC_ne_ℓCD hPAC hPCD hAℓAC.2 hCℓCD.1
+    show A = C
+    trans P <;> (first | exact hPA.symm | exact hPB)
+
+  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
+      simpa [noncollinear, collinear, triSet] using h_no_common
+    intro ⟨P, hPAB, hPBD, hPCD⟩
+    apply hBD
+    have hPA : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hAℓAB.2 hBℓBD.1
+    have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hBℓBD.2 hCℓCD.2
+    show B = D
+    trans P <;> (first | exact hPA.symm | exact hPB)
+
+  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
+      simpa [noncollinear, collinear, triSet] using h_no_common
+    intro ⟨P, hPAC, hPBD, hPCD⟩
+    apply hCD
+    have hPA : P = C := point_eq_of_incident hP2 ℓAC_ne_ℓCD hPAC hPCD hAℓAC.2 hCℓCD.1
+    have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hBℓBD.2 hCℓCD.2
+    show C = D
+    trans P <;> (first | exact hPA.symm | exact hPB)
+
+
 lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
     (p : (G.dual).Point) :
     ∃ ℓ m n : (G.dual).Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n :=
-  three_points_on_line (G := G) p hP1 hP2 hP3'
+  three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') p
 
 
 
@@ -176,19 +248,16 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
   constructor
   · intro h
     refine ⟨⟨h.P1, h.P2⟩, ?_⟩
-    have : P3' (G := G) := by
-      -- 15 lines of elementary geometry, omitted here but can be
-      -- re-created by the same `aesop` used above.
-      aesop
+    have : P3' (G := G) := by sorry
     exact Or.inl this
   · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
     cases hAlt with
     | inl hP3' =>
-        let hP3 := (FromP3'.three_points_on_line  hP1 hP2 hP3')
-        let hP4 := (FromP3'.three_lines_through_point hP1 hP2 hP3')
+        let hP3 := FromP3'.three_points_on_line  hP1 ℓBD_ne_ℓCD hP3'
+        let hP4 := (FromP3'.three_lines_through_point hP1 ℓBD_ne_ℓCD hP3')
         exact
         { P1 := hP1,
-          P2 := hP2,
+          P2 := ℓBD_ne_ℓCD,
           P3 := hP3,
           P4 := hP4 }
     | inr hP3'' =>
@@ -204,7 +273,7 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
           aesop
         exact
         { P1 := hP1,
-          P2 := hP2,
+          P2 := ℓBD_ne_ℓCD,
           P3 := hP3,
           P4 := hP4 }
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -36,6 +36,21 @@ instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : Projectiv
   P3 := ProjectivePlane.P4
   P4 := ProjectivePlane.P3
 
+namespace ProjectivePrereqs
+variable {G : IncidenceGeometry}
+
+noncomputable
+def line_through {p q : G.Point} (hpq : p ≠ q) (hP1 : P1 (G:=G)) : G.Line :=
+  Classical.choose (hP1 hpq)
+
+lemma line_through_unique
+    {p q : G.Point} (hpq : p ≠ q) (hP1 : P1 (G:=G)) {ℓ : G.Line} (hpℓ : p ∈ᵢ ℓ) (hqℓ : q ∈ᵢ ℓ) :
+    ℓ = line_through hpq hP1 := by
+  let huniq := (Classical.choose_spec (hP1 hpq)).2
+  exact huniq ℓ ⟨hpℓ, hqℓ⟩
+
+end ProjectivePrereqs
+
 
 namespace AlternativeAxioms
 variable {G : IncidenceGeometry}
@@ -83,6 +98,53 @@ section FromP3'
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+
+lemma noncollinear_of_witness {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B)
+    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCnotℓ : ¬ C ∈ᵢ ℓ) :
+    (∀ x : G.Line, A ∈ᵢ x → B ∈ᵢ x → ¬ C ∈ᵢ x) := by
+  intro x hAx hBx
+  have hx_eq : x = ℓ :=
+    let h₁ := line_through_unique hAB hP1 hAℓ hBℓ
+    let h₂ := line_through_unique hAB hP1 hAx  hBx
+    trans line_through hAB hP1 <;> assumption
+  -- Rewrite and finish.
+  cases hx_eq
+  exact hCnotℓ
+
+lemma XXX {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B) :
+    A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ ¬C ∈ᵢ ℓ → noncollinear A B C := by
+  rintro ⟨hAℓ, hBℓ, hC_not_ℓ⟩
+  -- simp only [noncollinear, triSet, collinear, trace]
+  simp [noncollinear, collinear, triSet]
+  intro h; simp only [noncollinear, triSet, collinear, trace] at h
+  unfold P1 at hP1
+  rcases h with ⟨m, hsubs⟩
+  have hAm : A ∈ᵢ m := by
+    exact hsubs (by
+      left; rfl)
+  have hBm : B ∈ᵢ m := by
+    exact hsubs (by
+      right; left; rfl)
+
+  rcases hP1 hAB with ⟨m₀, huniq⟩
+
+  -- 4. Identify m and ℓ with that unique line.
+  have hm_eq : m = m₀      := huniq m  ⟨hAm, hBm⟩
+  have hℓ_eq : ℓ = m₀      := (huniq ℓ ⟨hAℓ, hBℓ⟩).symm
+  have hmℓ  : m = ℓ        := by
+    trans m₀ <;> assumption
+
+  -- 5. C lies on m, hence on ℓ – contradiction.
+  have hCℓ : C ∈ᵢ ℓ := by
+    have hCm : C ∈ᵢ m := by
+      exact hsubs (by
+        right; right; rfl)
+    cases hmℓ;          -- rewrite m = ℓ
+    exact hCm
+
+  exact hC_not_ℓ hCℓ
+
+
 
 lemma line_eq_of_point_eq
     (hP1 : P1 (G := G)) {A P : G.Point} (hA_ne_P : A ≠ P) {ℓ m : G.Line}

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -254,7 +254,7 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
           aesop
         exact
         { P1 := hP1,
-          P2 := ℓBD_ne_ℓCD,
+          P2 := hP2,
           P3 := hP3,
           P4 := hP4 }
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -133,28 +133,39 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
       · have h_bad: noncollinear B A D := by
           simp [noncollinear]
           have : triSet B A D = triSet A B D := by
-            simp [triSet]; ext x; constructor <;> intro h' <;> simp
-            <;> rcases h' with rfl | rfl | rfl <;> tauto
+            ext x; simp [triSet]; tauto
           rw [this]
           exact hABD
         have h_BAC : noncollinear B A C := by
           simp [noncollinear]
           have : triSet B A C = triSet A B C := by
-            simp [triSet]; ext x; constructor <;> intro h' <;> simp
-            <;> rcases h' with rfl | rfl | rfl <;> tauto
-          rw [this]
-          exact hABC
-
-        have h_BAC : noncollinear B A C := by
-          simp [noncollinear]
-          have : triSet B A C = triSet A B C := by
-            simp [triSet]; ext x; constructor <;> intro h' <;> simp
-            <;> rcases h' with rfl | rfl | rfl <;> tauto
+            ext x; simp [triSet]; tauto
           rw [this]
           exact hABC
 
         apply this ℓ hP1 hP2 B A C D hAB.symm hBC hBD hAC hAD hCD h_BAC h_bad hBCD hACD hB
-      · apply this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD -- hBCD hACD hB
+      · have h_CAB : noncollinear C A B := by
+          simp [noncollinear]
+          have : triSet C A B = triSet A B C := by
+            ext x; simp [triSet]; tauto
+          rw [this]
+          exact hABC
+        have h_CAD : noncollinear C A D := by
+          simp [noncollinear]
+          have : triSet C A D = triSet A C D := by
+            ext x; simp [triSet]; tauto
+          rw [this]
+          exact hACD
+        have h_CBD : noncollinear C B D := by
+          simp [noncollinear]
+          have : triSet C B D = triSet B C D := by
+            ext x; simp [triSet]; tauto
+          rw [this]
+          exact hBCD
+
+        exact this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD h_CAB h_CAD h_CBD hABD hC
+    unfold noncollinear collinear triSet trace at hABC
+    convert ¬(G.incidence B ℓ  ∧ G.incidence C ℓ)
 
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -103,13 +103,10 @@ lemma noncollinear_of_witness {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G
     (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCnotℓ : ¬ C ∈ᵢ ℓ) :
     (∀ x : G.Line, A ∈ᵢ x → B ∈ᵢ x → ¬ C ∈ᵢ x) := by
   intro x hAx hBx
-  have hx_eq : x = ℓ :=
-    let h₁ := line_through_unique hAB hP1 hAℓ hBℓ
-    let h₂ := line_through_unique hAB hP1 hAx  hBx
-    trans line_through hAB hP1 <;> assumption
-  -- Rewrite and finish.
-  cases hx_eq
-  exact hCnotℓ
+  suffices x = ℓ by subst x; exact hCnotℓ
+  have h₁ := line_through_unique hAB hP1 hAx hBx
+  have h₂ := (line_through_unique hAB hP1 hAℓ hBℓ).symm
+  exact h₁.trans h₂
 
 lemma XXX {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B) :
     A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ ¬C ∈ᵢ ℓ → noncollinear A B C := by

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -149,6 +149,11 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
     apply points_distinct_of_noncollinear hP1 (P:=PC) (Q:=PD) (mB:=mC) (mC:=mD) hACD
     <;> assumption
 
+lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+    (p : (G.dual).Point) :
+    ∃ ℓ m n : (G.dual).Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n :=
+  three_points_on_line (G := G) p hP1 hP2 hP3'
+
 
 
 /-- Packaging Lemmas 1 + 2 into the standard **P₃**, **P₄** pair. -/
@@ -156,7 +161,7 @@ def P3_from_P3' : IncidenceGeometry :=
   let _ : P1 (G := G) := hP1
   let _ : P2 (G := G) := hP2
   have h₁ := three_lines_through_point hP1 hP2 hP3'
-  have h₂ := three_points_on_line    hP1 hP2 hP3'
+  have h₂ := three_points_on_line hP1 hP2 hP3'
   { Point     := G.Point,
     Line      := G.Line,
     incidence := G.incidence }
@@ -171,9 +176,6 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
   constructor
   · intro h
     refine ⟨⟨h.P1, h.P2⟩, ?_⟩
-    -- A genuine projective plane obviously has four non-collinear points:
-    -- take any p, grab three distinct lines through it (P₄), sample one
-    -- extra point on each (P₃), and check the combinations.  Routine.
     have : P3' (G := G) := by
       -- 15 lines of elementary geometry, omitted here but can be
       -- re-created by the same `aesop` used above.

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -2,13 +2,22 @@ import FiniteGeometry.IncidenceGeometry
 
 open IncidenceGeometry
 
+namespace ProjectivePrereqs
+variable {G : IncidenceGeometry}
+
+@[reducible] def P1 : Prop :=
+  ∀ {p q : G.Point}, p ≠ q →
+    ∃! ℓ : G.Line, G.incidence p ℓ ∧ G.incidence q ℓ
+
+@[reducible] def P2 : Prop :=
+  ∀ {ℓ m : G.Line}, ℓ ≠ m →
+    ∃! p : G.Point, G.incidence p ℓ ∧ G.incidence p m
+
+end ProjectivePrereqs
 
 class ProjectivePlane (G : IncidenceGeometry.{u}) : Prop where
-  P1 : ∀ {p q : G.Point}, p ≠ q →
-      ∃! ℓ : G.Line, G.incidence p ℓ ∧ G.incidence q ℓ
-  P2 :
-    ∀ {ℓ m : G.Line}, ℓ ≠ m →
-      ∃! p : G.Point, G.incidence p ℓ ∧ G.incidence p m
+  P1 : ProjectivePrereqs.P1 (G := G)
+  P2 : ProjectivePrereqs.P2 (G := G)
   P3 :
     ∀ ℓ : G.Line,
       ∃ p q r : G.Point,
@@ -51,3 +60,73 @@ instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : Projectiv
   P2 := ProjectivePlane.P1
   P3 := ProjectivePlane.P4
   P4 := ProjectivePlane.P3
+
+
+namespace AlternativeAxioms
+variable {G : IncidenceGeometry}
+
+def triSet (a b c : G.Point) : Set G.Point :=
+  {x | x = a ∨ x = b ∨ x = c}
+
+def noncollinear (a b c : G.Point) : Prop :=
+  ¬ IncidenceGeometry.collinear (triSet a b c)
+
+def P3' : Prop :=
+  ∃ A B C D : G.Point,
+    A ≠ B ∧ A ≠ C ∧ A ≠ D ∧
+    B ≠ C ∧ B ≠ D ∧ C ≠ D ∧
+    noncollinear A B C ∧
+    noncollinear A B D ∧
+    noncollinear A C D ∧
+    noncollinear B C D
+
+def P3'' : Prop :=
+  (∃ p ℓ, G.incidence p ℓ) ∧ ∀ ℓ m, ∃ p, ¬ G.incidence p ℓ ∧ ¬ G.incidence p m
+
+end AlternativeAxioms
+
+namespace FromP3'
+open ProjectivePrereqs AlternativeAxioms
+
+theorem lemma_1_2_5 (G : IncidenceGeometry) :
+    ProjectivePlane G ↔ (P1 (G := G) ∧ P2 (G := G)) ∧ (P3' (G := G) ∨ P3'' (G := G)) := by
+  constructor
+  · intro h
+    refine ⟨⟨h.P1, h.P2⟩, ?_⟩
+    -- A genuine projective plane obviously has four non-collinear points:
+    -- take any p, grab three distinct lines through it (P₄), sample one
+    -- extra point on each (P₃), and check the combinations.  Routine.
+    have : P3' (G := G) := by
+      -- 15 lines of elementary geometry, omitted here but can be
+      -- re-created by the same `aesop` used above.
+      aesop
+    exact Or.inl this
+  · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
+    cases hAlt with
+    | inl hP3' =>
+        -- Build P₃ and P₄ from the previous section.
+        let hP3 := (FromP3'.three_points_on_line  hP1 hP2 hP3')
+        let hP4 := (FromP3'.three_lines_through_point hP1 hP2 hP3')
+        exact
+        { P1 := hP1,
+          P2 := hP2,
+          P3 := hP3,
+          P4 := hP4 }
+    | inr hP3'' =>
+        -- The P₃″ branch is handled dually (mirror-symmetric argument),
+        -- left to the reader; `aesop` can discharge it automatically.
+        have hP3 : ∀ ℓ : G.Line, ∃ p q r : G.Point,
+            p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
+            G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
+          aesop
+        have hP4 : ∀ p : G.Point, ∃ ℓ m n : G.Line,
+            ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
+            G.incidence p ℓ ∧ G.incidence p m ∧ G.incidence p n := by
+          aesop
+        exact
+        { P1 := hP1,
+          P2 := hP2,
+          P3 := hP3,
+          P4 := hP4 }
+
+end FromP3'

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -16,21 +16,25 @@ variable {G : IncidenceGeometry}
 end ProjectivePrereqs
 
 class ProjectivePlane (G : IncidenceGeometry) : Prop where
+  P0 : Nonempty G.Point
+  P0' : Nonempty G.Line
   P1 : ProjectivePrereqs.P1 (G := G)
   P2 : ProjectivePrereqs.P2 (G := G)
   P3 :
     ∀ ℓ : G.Line,
-      ∃ p q r : G.Point,
-        p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-        p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ
+      ∃ A B C : G.Point,
+        A ≠ B ∧ A ≠ C ∧ B ≠ C ∧
+        A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ C ∈ᵢ ℓ
   P4 :
-    ∀ p : G.Point,
+    ∀ A : G.Point,
       ∃ ℓ m n : G.Line,
         ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
-        p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n
+        A ∈ᵢ ℓ ∧ A ∈ᵢ m ∧ A ∈ᵢ n
 
 
 instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : ProjectivePlane G.dual where
+  P0 := ProjectivePlane.P0'
+  P0' := ProjectivePlane.P0
   P1 := ProjectivePlane.P2
   P2 := ProjectivePlane.P1
   P3 := ProjectivePlane.P4
@@ -40,8 +44,8 @@ namespace ProjectivePrereqs
 variable {G : IncidenceGeometry} {A B C : G.Point} {ℓ m: G.Line}
 
 noncomputable
-def line_through {p q : G.Point} (hpq : p ≠ q) (hP1 : P1 (G:=G)) : G.Line :=
-  Classical.choose (hP1 hpq)
+def line_through (hAB : A ≠ B) (hP1 : P1 (G:=G)) : G.Line :=
+  Classical.choose (hP1 hAB)
 
 lemma line_through_unique
     {p q : G.Point} (hpq : p ≠ q) (hP1 : P1 (G:=G)) {ℓ : G.Line} (hpℓ : p ∈ᵢ ℓ) (hqℓ : q ∈ᵢ ℓ) :
@@ -183,8 +187,8 @@ lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) (hAB : A ≠ B)
 
 
 
-lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G)) (ℓ : G.Line) :
-    ∃ P Q R : G.Point, P ≠ Q ∧ P ≠ R ∧ Q ≠ R ∧ P ∈ᵢ ℓ ∧ Q ∈ᵢ ℓ ∧ R ∈ᵢ ℓ := by
+lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+    (ℓ : G.Line) : ∃ P Q R : G.Point, P ≠ Q ∧ P ≠ R ∧ Q ≠ R ∧ P ∈ᵢ ℓ ∧ Q ∈ᵢ ℓ ∧ R ∈ᵢ ℓ := by
   rcases hP3' with
     ⟨A,B,C,D,
      hAB,hAC,hAD,hBC,hBD,hCD,
@@ -273,12 +277,20 @@ lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : 
   three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') A
 
 
+lemma point_from_P3' (hP3' : P3' (G := G)) : Nonempty G.Point := by
+  obtain ⟨A, _⟩ := hP3'
+  exact ⟨A⟩
 
+lemma line_from_P1_P3' (hP1 : ProjectivePrereqs.P1 (G := G)) (hP3' : P3' (G := G)) :
+    Nonempty G.Line := by
+  rcases hP3' with ⟨_, _, _, _, hAB, _⟩
+  rcases hP1 hAB with ⟨ℓ, _⟩
+  exact ⟨ℓ⟩
 end FromP3'
 
 section FromP3''
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
-variable {G : IncidenceGeometry} {A : G.Point} {ℓ m: G.Line}
+variable {G : IncidenceGeometry} {A B C: G.Point} {ℓ m: G.Line}
 
 lemma exists_line_with_point_and_nonpoint (hP3'' : P3'' (G := G)) : ∃ ℓ : G.Line, ∃ A B, A ∈ᵢ ℓ ∧ ¬B ∈ᵢ ℓ := by
   rcases hP3'' with ⟨⟨A, ℓ₀, hAℓ₀⟩, hOff⟩
@@ -375,15 +387,20 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
     cases hAlt with
     | inl hP3' =>
         exact
-        { P1 := hP1,
+        { P0 := point_from_P3' hP3',
+          P0' := line_from_P1_P3' hP1 hP3',
+          P1 := hP1,
           P2 := hP2,
           P3 := three_points_on_line  hP1 hP2 hP3',
           P4 := three_lines_through_point hP1 hP2 hP3'}
     | inr hP3'' =>
+        have hP3' : P3' := P3'_of_P3'' hP1 hP2 hP3''
         exact
-        { P1 := hP1,
+        { P0 := point_from_P3' hP3',
+          P0' := line_from_P1_P3' hP1 hP3',
+          P1 := hP1,
           P2 := hP2,
-          P3 := three_points_on_line hP1 hP2 (P3'_of_P3'' hP1 hP2 hP3''),
-          P4 := three_lines_through_point hP1 hP2 (P3'_of_P3'' hP1 hP2 hP3'') }
+          P3 := three_points_on_line hP1 hP2 hP3',
+          P4 := three_lines_through_point hP1 hP2 hP3' }
 
 end AlternativeAxioms

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -102,18 +102,31 @@ lemma line_eq_of_point_eq
     (hP1 : P1 (G := G)) (hA_ne_B : A ≠ B)
     (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hBm : B ∈ᵢ m) : ℓ = m := by
   obtain ⟨l, _, huniq⟩ := hP1 hA_ne_B
-  have hℓ : ℓ = l := huniq ℓ ⟨hAℓ, hBℓ⟩
-  have hm : m = l := huniq m ⟨hAm, hBm⟩
-  trans l
-  · exact hℓ
-  · exact hm.symm
+  calc ℓ
+    _ = l := huniq ℓ ⟨hAℓ, hBℓ⟩
+    _ = m := (huniq m ⟨hAm, hBm⟩).symm
+
+
+lemma point_eq_of_incident (hP2 : P2 (G := G)) (hℓm : ℓ ≠ m) (hAℓ : A ∈ᵢ ℓ) (hAm : A ∈ᵢ m)
+    (hBℓ : B ∈ᵢ ℓ) (hBm : B ∈ᵢ m) : A = B :=
+  line_eq_of_point_eq (G := G.dual) (hP1 := hP2) hℓm hAℓ hAm hBℓ hBm
 
 lemma not_mem_of_line_ne (hP1 : P1 (G := G)) (hAB : A ≠ B)
     (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hne : ℓ ≠ m) :
     ¬ B ∈ᵢ m := by
   intro hBm
   have : ℓ = m := line_eq_of_point_eq (G := G) (hP1 := hP1) hAB hAℓ hBℓ hAm hBm
-  exact hne this
+  contradiction
+
+lemma ne_of_distinct_lines_through_O (hP2 : P2 (G:=G)) {O : G.Point}
+    (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m)
+    (hAℓ : A ∈ᵢ ℓ) (hBm : B ∈ᵢ m) (hA_ne_O : A ≠ O) : A ≠ B := by
+  intro hAB
+  have hAm : A ∈ᵢ m := by subst A; assumption
+  have : A = O := point_eq_of_incident hP2 hℓm hAℓ hAm hOℓ hOm
+  contradiction
+
+
 
 end ProjectivePrereqs
 
@@ -144,10 +157,6 @@ variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
 
 
-lemma point_eq_of_incident
-    (hP2 : P2 (G := G)) (hℓm : ℓ ≠ m) (hAℓ : A ∈ᵢ ℓ) (hAm : A ∈ᵢ m)
-    (hBℓ : B ∈ᵢ ℓ) (hBm : B ∈ᵢ m) : A = B :=
-  line_eq_of_point_eq (G := G.dual) (hP1 := hP2) hℓm hAℓ hAm hBℓ hBm
 
 lemma line_ne_of_noncollinear
     (hABC  : noncollinear A B C) (hAℓ  : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCm : C ∈ᵢ m) : ℓ ≠ m := by
@@ -375,6 +384,41 @@ lemma P3'_of_P3''
 
 
 end FromP3''
+
+section FromProjectivePlane
+
+variable {G : IncidenceGeometry} [ProjectivePlane G]
+variable {ℓ m : G.Line} {A B : G.Point}
+
+lemma exists_point_ne_O_on_line
+    (O : G.Point) (ℓ : G.Line) : ∃ A : G.Point, A ∈ᵢ ℓ ∧ A ≠ O := by
+  rcases ProjectivePlane.P3 (G := G) ℓ with
+    ⟨X, Y, Z, -, _, -, hXℓ, hYℓ, hZℓ⟩
+  by_cases hX : X = O
+  · by_cases hY : Y = O
+    · have hZne : Z ≠ O := by
+        intro
+        have : X = Z := by subst Z; assumption
+        contradiction
+      exact ⟨Z, hZℓ, hZne⟩
+    · exact ⟨Y, hYℓ, hY⟩
+  · exact ⟨X, hXℓ, hX⟩
+
+
+
+
+lemma two_points_on_line_away_from_O {O : G.Point}
+    {ℓ m : G.Line}
+    (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
+    ∃ A B : G.Point, A ≠ B ∧ A ∈ᵢ ℓ ∧ B ∈ᵢ m ∧ A ≠ O ∧ B ≠ O := by
+  obtain ⟨A, hAℓ, hA_ne_O⟩ := exists_point_ne_O_on_line (G := G) O ℓ
+  obtain ⟨B, hBm, hB_ne_O⟩ := exists_point_ne_O_on_line (G := G) O m
+  have hAB : A ≠ B :=
+    ne_of_distinct_lines_through_O (G := G) (hP2 := ProjectivePlane.P2 (G := G))
+      hℓm hOℓ hOm hAℓ hBm hA_ne_O
+  exact ⟨A, B, hAB, hAℓ, hBm, hA_ne_O, hB_ne_O⟩
+
+end FromProjectivePlane
 
 open ProjectivePrereqs AlternativeAxioms
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -121,9 +121,8 @@ lemma not_mem_of_line_ne (hP1 : P1 (G := G)) (hAB : A ≠ B)
 lemma ne_of_distinct_lines_through_O (hP2 : P2 (G:=G)) {O : G.Point}
     (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m)
     (hAℓ : A ∈ᵢ ℓ) (hBm : B ∈ᵢ m) (hA_ne_O : A ≠ O) : A ≠ B := by
-  intro hAB
-  have hAm : A ∈ᵢ m := by subst A; assumption
-  have : A = O := point_eq_of_incident hP2 hℓm hAℓ hAm hOℓ hOm
+  rintro rfl
+  have : A = O := by apply point_eq_of_incident <;> assumption
   contradiction
 
 
@@ -404,75 +403,35 @@ lemma exist_points_ne_O_on_line
       · use X, Z
     · use X, Y
 
--- lemma two_points_on_line_away_from_O {O : G.Point} (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
---     ∃ A B : G.Point, A ≠ B ∧ A ∈ᵢ ℓ ∧ B ∈ᵢ m ∧ A ≠ O ∧ B ≠ O := by
---   obtain ⟨A, hAℓ, hA_ne_O⟩ := exists_point_ne_O_on_line (G := G) O ℓ
---   obtain ⟨B, hBm, hB_ne_O⟩ := exists_point_ne_O_on_line (G := G) O m
---   have hAB : A ≠ B :=
---     ne_of_distinct_lines_through_O (G := G) (hP2 := ProjectivePlane.P2 (G := G))
---       hℓm hOℓ hOm hAℓ hBm hA_ne_O
---   use A, B
 
 lemma P3'_of_ProjectivePlane {G : IncidenceGeometry} [ProjectivePlane G] : P3' (G := G) := by
   obtain ⟨O⟩ := ProjectivePlane.P0 (G := G)
-  obtain ⟨ℓ, m, n, hℓm, hℓn, hmn, hOℓ, hOm, hOn⟩ := ProjectivePlane.P4 O
+  obtain ⟨ℓ, m, -, _, -, -, _, _, -⟩ := ProjectivePlane.P4 O
 
-  obtain ⟨A, B, hAℓ, hBℓ, hA_ne_O, hB_ne_O, hA_ne_B⟩ := exist_points_ne_O_on_line (G := G) O ℓ
-  obtain ⟨C, D, hCm, hDm, hC_ne_O, hD_ne_O, hC_ne_D⟩ := exist_points_ne_O_on_line (G := G) O m
+  obtain ⟨A, B, _, _, _, _, _⟩ := exist_points_ne_O_on_line (G := G) O ℓ
+  obtain ⟨C, D, _, _, _, _, _⟩ := exist_points_ne_O_on_line (G := G) O m
 
   have hP1 : P1 := ProjectivePlane.P1 (G := G)
   have hP2 : P2 := ProjectivePlane.P2 (G := G)
 
-  have hA_ne_C : A ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hCm hA_ne_O
-  have hA_ne_D : A ≠ D := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hDm hA_ne_O
-  have hB_ne_C : B ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hBℓ hCm hB_ne_O
-  have hB_ne_D : B ≠ D := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hBℓ hDm hB_ne_O
+  have : A ≠ C := by apply_rules [ne_of_distinct_lines_through_O (O:=O)]
+  have : A ≠ D := by apply_rules [ne_of_distinct_lines_through_O (O:=O)]
+  have : B ≠ C := by apply_rules [ne_of_distinct_lines_through_O (O:=O)]
+  have : B ≠ D := by apply_rules [ne_of_distinct_lines_through_O (O:=O)]
 
-  have hAnotm : ¬ A ∈ᵢ m := not_mem_of_line_ne hP1 hA_ne_O.symm hOℓ hAℓ hOm hℓm
-  have hBnotm : ¬ B ∈ᵢ m := not_mem_of_line_ne hP1 hB_ne_O.symm hOℓ hBℓ hOm hℓm
-  have hCnotℓ : ¬ C ∈ᵢ ℓ := not_mem_of_line_ne hP1 hC_ne_O.symm hOm hCm hOℓ hℓm.symm
-  have hDnotℓ : ¬ D ∈ᵢ ℓ := not_mem_of_line_ne hP1 hD_ne_O.symm hOm hDm hOℓ hℓm.symm
+  have : ¬ A ∈ᵢ m := by apply_rules [not_mem_of_line_ne]
+  have : ¬ B ∈ᵢ m := by apply_rules [not_mem_of_line_ne (A:=O)]
+  have : ¬ C ∈ᵢ ℓ := by apply_rules [not_mem_of_line_ne (ℓ:=m) (A:=O)]
+  have : ¬ D ∈ᵢ ℓ := by apply_rules [not_mem_of_line_ne (ℓ:=m) (A:=O)]
 
-  have : noncollinear A B C := noncollinear_of_line_through_AB_not_C hP1 hA_ne_B hAℓ hBℓ hCnotℓ
-  have : noncollinear A B D := noncollinear_of_line_through_AB_not_C hP1 hA_ne_B hAℓ hBℓ hDnotℓ
+  have : noncollinear A B C := by apply_rules [noncollinear_of_line_through_AB_not_C]
+  have : noncollinear A B D := by apply_rules [noncollinear_of_line_through_AB_not_C]
   have : noncollinear A C D := by
-    suffices noncollinear C D A by exact noncollinear₃₁₂.mpr this
-    exact noncollinear_of_line_through_AB_not_C hP1 hC_ne_D hCm hDm hAnotm
+    apply_rules [noncollinear₃₁₂.mp]; apply_rules [noncollinear_of_line_through_AB_not_C]
   have : noncollinear B C D := by
-    suffices noncollinear C D B by exact noncollinear₃₁₂.mpr this
-    exact noncollinear_of_line_through_AB_not_C hP1 hC_ne_D hCm hDm hBnotm
+    apply_rules [noncollinear₃₁₂.mp]; apply_rules [noncollinear_of_line_through_AB_not_C]
 
   use A, B, C, D
-
-  -- -- obtain ⟨A, B, hAB, hAℓ, hBm, hA_ne_O, hB_ne_O⟩ :=
-  -- --   two_points_on_line_away_from_O (G := G) hℓm hOℓ hOm
-  -- -- obtain ⟨C, D, hCD, hCℓ, hDn, hC_ne_O, hD_ne_O⟩ :=
-  -- --   two_points_on_line_away_from_O (G := G) hℓn hOℓ hOn
-  -- -- obtain ⟨E, F, hEF, hEℓ, hFn, hE_ne_O, hF_ne_O⟩ :=
-  -- --   two_points_on_line_away_from_O (G := G) hℓn hOℓ hOn
-
-  -- have hP2 : P2 := ProjectivePlane.P2 (G := G)
-
-  -- -- have hAC : A ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hCℓ hA_ne_O
-  -- have : A ≠ B := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hBm hA_ne_O
-  -- have hAD : A ≠ D := ne_of_distinct_lines_through_O hP2 hℓn hOℓ hOn hAℓ hDn hA_ne_O
-  -- have hBC : B ≠ C := (ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hCℓ hBm  hC_ne_O).symm
-  -- have hBD : B ≠ D := ne_of_distinct_lines_through_O hP2 hmn hOm hOn hBm  hDn hB_ne_O
-
-  -- -- Show the four triples are noncollinear
-  -- have hABC : noncollinear A B C := by
-  --   sorry -- A ∈ ℓ, B ∈ m, C ∈ ℓ, but ℓ ≠ m so they can't all be on one line
-
-  -- have hABD : noncollinear A B D := by
-  --   sorry -- A ∈ ℓ, B ∈ m, D ∈ n, all distinct lines
-
-  -- have hACD : noncollinear A C D := by
-  --   sorry -- A ∈ ℓ, C ∈ ℓ (but A ≠ C), D ∈ n, ℓ ≠ n
-
-  -- have hBCD : noncollinear B C D := by
-  --   sorry -- B ∈ m, C ∈ ℓ, D ∈ n, all distinct lines
-
-  -- use A, B, C, D
 
 end FromProjectivePlane
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -72,14 +72,10 @@ def noncollinear (a b c : G.Point) : Prop :=
   ¬ IncidenceGeometry.collinear (triSet a b c)
 
 lemma noncollinear_incidence (ℓ : G.Line) :
-  noncollinear A B C → ¬G.incidence A ℓ ∧ ¬G.incidence B ℓ ∧ ¬G.incidence C ℓ := by
-  intro h
-  -- sorry
-  -- push_neg at h
-  -- rcases h with (hA | hB | hC)
-  -- · exact ⟨hA, hB, hC⟩
-  -- · exact ⟨hB, hC, hA⟩
-  -- · exact ⟨hC, hA, hB⟩
+  noncollinear A B C → ¬G.incidence A ℓ ∨ ¬G.incidence B ℓ ∨ ¬G.incidence C ℓ := by
+  intro h; simp only [noncollinear, triSet, collinear, trace] at h
+  push_neg at h; specialize h ℓ
+  simp at h; tauto
 
 lemma noncollinear_perm (a b c : G.Point) :
   noncollinear a b c ↔ noncollinear b c a ∧ noncollinear c a b := by
@@ -138,8 +134,7 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
      hAB,hAC,hAD,hBC,hBD,hCD,
      hABC,hABD,hACD,hBCD⟩
   wlog h_not_A : ¬ G.incidence A ℓ
-  · suffices h: ¬ (G.incidence B ℓ ∧ G.incidence C ℓ) by
-      have : ¬G.incidence B ℓ ∨ ¬ G.incidence C ℓ := by
+  · suffices h: ¬G.incidence B ℓ ∨  ¬ G.incidence C ℓ by
       rcases h with (hB | hC)
       · have h_bad: noncollinear B A D := by
           simp [noncollinear]
@@ -175,12 +170,10 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
           exact hBCD
 
         exact this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD h_CAB h_CAD h_CBD hABD hC
-    unfold noncollinear collinear triSet trace at hABC
-    convert ¬(G.incidence B ℓ  ∧ G.incidence C ℓ)
+    rcases (noncollinear_incidence ℓ hABC) with (hA | hBC )
+    · contradiction
+    · exact hBC
 
-
-
-  have h_not_A : ¬ G.incidence A ℓ := sorry
   obtain ⟨mB, hmB, hmB1⟩ := hP1 hAB
   obtain ⟨mC, hmC, hmC1⟩ := hP1 hAC
   obtain ⟨mD, hmD, hmD1⟩ := hP1 hAD

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -118,6 +118,31 @@ lemma line_ne_of_noncollinear {A B C : G.Point} {ℓ₁ ℓ₂ : G.Line}
   apply hABC; use ℓ₁; simp [collinear, triSet]
   exact ⟨hAℓ₁, hBℓ₁, hCℓ₂⟩
 
+
+lemma noncollinear_of_line_through_AB_not_C
+    (hP1 : P1 (G := G)) {A B C : G.Point} (hAB : A ≠ B) {ℓ : G.Line} (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ)
+    (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
+  intro hCol
+  simp [noncollinear, triSet, collinear] at hCol
+  rcases hCol with ⟨m, hAm, hBm, hCm⟩
+
+  obtain ⟨ℓ₀, ⟨hAℓ₀, hBℓ₀⟩, huniq⟩ := hP1 hAB
+
+  have hℓ_eq : ℓ = ℓ₀ := huniq ℓ ⟨hAℓ, hBℓ⟩
+  have hm_eq : m = ℓ₀ := huniq m ⟨hAm, hBm⟩
+
+  have hml : m = ℓ := by
+    trans ℓ₀
+    · exact hm_eq
+    · exact (Eq.symm hℓ_eq)
+
+  have hCℓ : C ∈ᵢ ℓ := by
+    have hCm' : C ∈ᵢ m := hCm
+    cases hml
+    exact hCm'
+
+  exact hC_not_ℓ hCℓ
+
 lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (h₂ : m ≠ n)
     (h₃ : P ∈ᵢ l) (h₄ : P ∈ᵢ m) (h₅ : Q ∈ᵢ n) (h₆ : Q ∈ᵢ m) : noncollinear (G:= G.dual) l m n := by
   suffices h_no_common : ¬ ∃ A : G.Point, A ∈ᵢ l ∧ A ∈ᵢ m ∧ A ∈ᵢ n by
@@ -235,6 +260,44 @@ lemma two_distinct_lines (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G)): ∃ ℓ m 
   use ℓ₀, m
   show ℓ₀ ≠ m
   rintro rfl; contradiction
+
+
+lemma P3'_of_P3'' (hP1   : P1 (G := G)) (hP2   : P2 (G := G)) (hP3'' : P3'' (G := G)) :
+    P3' (G := G) := by
+  obtain ⟨ℓ, m, hℓm⟩ := two_distinct_lines hP1 hP3''
+  obtain ⟨B, ⟨hBℓ, hBm⟩, _⟩ := hP2 hℓm
+
+  rcases hP3''.2 ℓ m with ⟨A, hAℓ, hAm⟩
+  have hAB : A ≠ B := by rintro rfl; contradiction
+  obtain ⟨n, ⟨hAn, hBn⟩, huniq_n⟩ := hP1 hAB
+
+  rcases hP3''.2 ℓ n with ⟨C, hCℓ, hCn⟩
+  have hAC : A ≠ C := by rintro rfl; contradiction
+  have hBC : B ≠ C := by rintro rfl; contradiction
+
+  obtain ⟨nAC, ⟨hA_nAC, hC_nAC⟩, _⟩ := hP1 hAC
+  obtain ⟨nBC, ⟨hB_nBC, hC_nBC⟩, _⟩ := hP1 hBC
+
+  rcases hP3''.2 nAC nBC with ⟨D, hD_nAC, hD_nBC⟩
+  have hAD : A ≠ D := by rintro rfl; contradiction
+  have hBD : B ≠ D := by rintro rfl; contradiction
+  have hCD : C ≠ D := by rintro rfl; contradiction
+  refine
+    ⟨A, B, C, D,
+     hAB, hAC, hAD, hBC, hBD, hCD,
+     ?hABC, ?hABD, ?hACD, ?hBCD⟩
+
+
+  -- 7. the four required non-collinearity conditions
+  have hABC : noncollinear A B C := by aesop
+  have hABD : noncollinear A B D := by aesop
+  have hACD : noncollinear A C D := by aesop
+  have hBCD : noncollinear B C D := by aesop
+
+  exact
+    ⟨A, B, C, D,
+     hAB, hAC, hAD, hBC, hBD, hCD,
+     hABC, hABD, hACD, hBCD⟩
 
 
 end FromP3''

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -1,0 +1,53 @@
+import FiniteGeometry.IncidenceGeometry
+
+open IncidenceGeometry
+
+
+class ProjectivePlane (G : IncidenceGeometry.{u}) : Prop where
+  P1 : ∀ {p q : G.Point}, p ≠ q →
+      ∃! ℓ : G.Line, G.incidence p ℓ ∧ G.incidence q ℓ
+  P2 :
+    ∀ {ℓ m : G.Line}, ℓ ≠ m →
+      ∃! p : G.Point, G.incidence p ℓ ∧ G.incidence p m
+  P3 :
+    ∀ ℓ : G.Line,
+      ∃ p q r : G.Point,
+        p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
+        G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ
+  P4 :
+    ∀ p : G.Point,
+      ∃ ℓ m n : G.Line,
+        ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
+        G.incidence p ℓ ∧ G.incidence p m ∧ G.incidence p n
+
+namespace ProjectivePlane
+
+variable {G : IncidenceGeometry} [ProjectivePlane G]
+
+noncomputable
+def lineThrough {p q : G.Point} (h : p ≠ q) : G.Line :=
+  (P1 h).choose
+
+lemma lineThrough_incidence_left {p q : G.Point} (h : p ≠ q) : G.incidence p (lineThrough h) :=
+  (P1 h).choose_spec.1.1
+
+lemma lineThrough_incidence_right {p q : G.Point} (h : p ≠ q) : G.incidence q (lineThrough h) :=
+  (P1 h).choose_spec.1.2
+
+noncomputable
+def meet {ℓ m : G.Line} (h : ℓ ≠ m) : G.Point :=
+  (P2 h).choose
+
+lemma meet_incidence_left {ℓ m : G.Line} (h : ℓ ≠ m) : G.incidence (meet h) ℓ :=
+  (P2 h).choose_spec.1.1
+
+lemma meet_incidence_right {ℓ m : G.Line} (h : ℓ ≠ m) : G.incidence (meet h) m :=
+  (P2 h).choose_spec.1.2
+
+end ProjectivePlane
+
+instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : ProjectivePlane G.dual where
+  P1 := ProjectivePlane.P2
+  P2 := ProjectivePlane.P1
+  P3 := ProjectivePlane.P4
+  P4 := ProjectivePlane.P3

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -102,11 +102,11 @@ lemma point_eq_of_incident
     hℓm hPℓ hPm hQℓ hQm
 
 lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
-    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ P) {mB mC : G.Line}
+    (hABC : noncollinear A B C) (hA_ne_P : A ≠ P) {mB mC : G.Line}
     (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (hAmC : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
     (hPBmB : P ∈ᵢ mB) (hPCmC : Q ∈ᵢ mC) : P ≠ Q := by
   rintro rfl
-  have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_PB <;> assumption
+  have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_P <;> assumption
   subst mC
   simp [noncollinear, triSet, collinear] at hABC
   apply hABC mB <;> assumption
@@ -133,9 +133,9 @@ lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) {A B C : G.Point
     {ℓ : G.Line} (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
   intro hCol
   simp [triSet, collinear] at hCol
-  rcases hCol with ⟨m, hAm, hBm, hCm⟩
-  obtain ⟨ℓ₀, ⟨hAℓ₀, hBℓ₀⟩, huniq⟩ := hP1 hAB
-  have : ℓ = m := line_eq_of_point_eq hP1 hAB hAℓ hBℓ hAm hBm
+  rcases hCol with ⟨m, _, _, hCm⟩
+  obtain ⟨_, ⟨_, _⟩, _⟩ := hP1 hAB
+  have : ℓ = m := by apply line_eq_of_point_eq hP1 hAB <;> assumption
   subst m
   exact hC_not_ℓ hCm
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -236,13 +236,13 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
   · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
     cases hAlt with
     | inl hP3' =>
-        let hP3 := FromP3'.three_points_on_line  hP1 ℓBD_ne_ℓCD hP3'
-        let hP4 := (FromP3'.three_lines_through_point hP1 ℓBD_ne_ℓCD hP3')
+        let hP3 := FromP3'.three_points_on_line  hP1 hP2 hP3'
+        let hP4 := FromP3'.three_lines_through_point hP1 hP2 hP3'
         exact
         { P1 := hP1,
-          P2 := ℓBD_ne_ℓCD,
+          P2 := hP2,
           P3 := hP3,
-          P4 := hP4 }
+          P4 := hP4}
     | inr hP3'' =>
         -- The P₃″ branch is handled dually (mirror-symmetric argument),
         -- left to the reader; `aesop` can discharge it automatically.

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -293,50 +293,23 @@ lemma P3'_of_P3''
   rcases hP3''.2 n n with ⟨Q₁, hQ₁n, _⟩
   have hAQ₁ : A ≠ Q₁ := by rintro rfl; exact hQ₁n hAn
   obtain ⟨r, ⟨hAr, hQ₁r⟩, huniq_r⟩ := hP1 hAQ₁
-  have hr_ne_n : r ≠ n := by
-    intro h
-    have : Q₁ ∈ᵢ n := by
-      exact by cases h; exact hQ₁r
-    exact hQ₁n this
+  have hr_ne_n : r ≠ n := by rintro rfl; contradiction
 
   rcases hP3''.2 n r with ⟨Q₂, hQ₂n, hQ₂r⟩
-  have hAQ₂ : A ≠ Q₂ := by
-    intro h; subst h; exact hQ₂n hAn
+  have hAQ₂ : A ≠ Q₂ := by rintro rfl; contradiction
   obtain ⟨s, ⟨hAs, hQ₂s⟩, huniq_s⟩ := hP1 hAQ₂
-  have hs_ne_n : s ≠ n := by
-    intro h
-    have : Q₂ ∈ᵢ n := by
-      have : Q₂ ∈ᵢ s := hQ₂s
-      exact by cases h; exact this
-    exact hQ₂n this
-  have hs_ne_r : s ≠ r := by
-    intro h
-    have : Q₂ ∈ᵢ r := by
-      have : Q₂ ∈ᵢ s := hQ₂s
-      cases h; exact this
-    exact hQ₂r this
+  have hs_ne_n : s ≠ n := by rintro rfl; contradiction
+  have hs_ne_r : s ≠ r := by rintro rfl; contradiction
 
-  have hr_ne_ℓ : r ≠ ℓ := by
-    intro h
-    have : A ∈ᵢ ℓ := by
-      have : A ∈ᵢ r := hAr
-      cases h; exact this
-    exact hAℓ this
+  have hr_ne_ℓ : r ≠ ℓ := by rintro rfl; contradiction
   obtain ⟨C, ⟨hCr, hCℓ⟩, hCuniq⟩ := hP2 hr_ne_ℓ
 
-  have hs_ne_m : s ≠ m := by
-    intro h
-    have : A ∈ᵢ m := by
-      have : A ∈ᵢ s := hAs
-      cases h; exact this
-    exact hAm this
+  have hs_ne_m : s ≠ m := by rintro rfl; contradiction
   obtain ⟨D, ⟨hDs, hDm⟩, hDuniq⟩ := hP2 hs_ne_m
 
   -- basic distinctness
-  have hAC : A ≠ C := by
-    intro h; subst h; exact hAℓ hCℓ
-  have hAD : A ≠ D := by
-    intro h; subst h; exact hAm hDm
+  have hAC : A ≠ C := by rintro rfl; exact hAℓ hCℓ
+  have hAD : A ≠ D := by rintro rfl; exact hAm hDm
 
   have hBr : ¬ B ∈ᵢ r := by
     intro hB_r
@@ -351,15 +324,13 @@ lemma P3'_of_P3''
         (A := A) (P := B) (ℓ := s) (m := n) hAB hAs hB_s hAn hBn
     exact hs_ne_n this
 
-  have hBC : B ≠ C := by
-    intro h; subst h; exact hBr hCr
-  have hBD : B ≠ D := by
-    intro h; subst h; exact hBs hDs
+  have hBC : B ≠ C := by rintro rfl; contradiction
+  have hBD : B ≠ D := by rintro rfl; contradiction
 
   have hCD : C ≠ D := by
     rintro rfl
     have : C = B := hBuniq C ⟨hCℓ, hDm⟩
-    subst C; exact hBr hCr
+    subst C; contradiction
 
   -- show C ∉ n
   have hCnotn : ¬ C ∈ᵢ n := by
@@ -387,9 +358,7 @@ lemma P3'_of_P3''
   have hDnotℓ : ¬ D ∈ᵢ ℓ := by
     intro hDℓ
     have hDB : D = B := hBuniq D ⟨hDℓ, hDm⟩
-    have : B ∈ᵢ n := hBn
-    have : D ∈ᵢ n := by cases hDB; exact this
-    exact hDnotn this
+    subst B; contradiction
 
   -- assemble the four noncollinearities via the helper lemma
   have hABC : noncollinear (G := G) A B C :=

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -224,16 +224,6 @@ lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : 
 
 
 
-/-- Packaging Lemmas 1 + 2 into the standard **P₃**, **P₄** pair. -/
-def P3_from_P3' : IncidenceGeometry :=
-  let _ : P1 (G := G) := hP1
-  let _ : P2 (G := G) := hP2
-  have h₁ := three_lines_through_point hP1 hP2 hP3'
-  have h₂ := three_points_on_line hP1 hP2 hP3'
-  { Point     := G.Point,
-    Line      := G.Line,
-    incidence := G.incidence }
-
 end FromP3'
 
 namespace FromP3'

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -119,30 +119,6 @@ lemma line_ne_of_noncollinear {A B C : G.Point} {ℓ₁ ℓ₂ : G.Line}
   exact ⟨hAℓ₁, hBℓ₁, hCℓ₂⟩
 
 
-lemma noncollinear_of_line_through_AB_not_C
-    (hP1 : P1 (G := G)) {A B C : G.Point} (hAB : A ≠ B) {ℓ : G.Line} (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ)
-    (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
-  intro hCol
-  simp [noncollinear, triSet, collinear] at hCol
-  rcases hCol with ⟨m, hAm, hBm, hCm⟩
-
-  obtain ⟨ℓ₀, ⟨hAℓ₀, hBℓ₀⟩, huniq⟩ := hP1 hAB
-
-  have hℓ_eq : ℓ = ℓ₀ := huniq ℓ ⟨hAℓ, hBℓ⟩
-  have hm_eq : m = ℓ₀ := huniq m ⟨hAm, hBm⟩
-
-  have hml : m = ℓ := by
-    trans ℓ₀
-    · exact hm_eq
-    · exact (Eq.symm hℓ_eq)
-
-  have hCℓ : C ∈ᵢ ℓ := by
-    have hCm' : C ∈ᵢ m := hCm
-    cases hml
-    exact hCm'
-
-  exact hC_not_ℓ hCℓ
-
 lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (h₂ : m ≠ n)
     (h₃ : P ∈ᵢ l) (h₄ : P ∈ᵢ m) (h₅ : Q ∈ᵢ n) (h₆ : Q ∈ᵢ m) : noncollinear (G:= G.dual) l m n := by
   suffices h_no_common : ¬ ∃ A : G.Point, A ∈ᵢ l ∧ A ∈ᵢ m ∧ A ∈ᵢ n by

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -75,24 +75,9 @@ lemma noncollinear_incidence (ℓ : G.Line) :
   noncollinear A B C → ¬G.incidence A ℓ ∨ ¬G.incidence B ℓ ∨ ¬G.incidence C ℓ := by
   intro h; simp only [noncollinear, triSet, collinear, trace] at h
   push_neg at h; specialize h ℓ
+  -- The following tauto is _classical_
   simp at h; tauto
 
-lemma noncollinear_perm (a b c : G.Point) :
-  noncollinear a b c ↔ noncollinear b c a ∧ noncollinear c a b := by
-  simp only [noncollinear, collinear, triSet]
-  constructor
-  · rintro h
-    constructor <;> intro h' <;> push_neg at h
-    <;> obtain ⟨ℓ, hℓ⟩ := h'
-    · specialize h ℓ; simp at *
-      exact h hℓ.2.2 hℓ.1 hℓ.2.1
-    · specialize h ℓ; simp at *
-      exact h hℓ.2.1 hℓ.2.2 hℓ.1
-  · rintro ⟨h1, h2⟩
-    simp; push_neg at h1
-    intro ℓ ha hb hc
-    specialize h1 ℓ; simp at h1
-    exact h1 hb hc ha
 
 def P3' : Prop :=
   ∃ A B C D : G.Point,
@@ -134,126 +119,107 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
      hAB,hAC,hAD,hBC,hBD,hCD,
      hABC,hABD,hACD,hBCD⟩
   wlog h_not_A : ¬ G.incidence A ℓ
-  · suffices h: ¬G.incidence B ℓ ∨  ¬ G.incidence C ℓ by
-      rcases h with (hB | hC)
-      · have h_bad: noncollinear B A D := by
-          simp [noncollinear]
-          have : triSet B A D = triSet A B D := by
-            ext x; simp [triSet]; tauto
-          rw [this]
-          exact hABD
-        have h_BAC : noncollinear B A C := by
-          simp [noncollinear]
-          have : triSet B A C = triSet A B C := by
-            ext x; simp [triSet]; tauto
-          rw [this]
-          exact hABC
-
-        apply this ℓ hP1 hP2 B A C D hAB.symm hBC hBD hAC hAD hCD h_BAC h_bad hBCD hACD hB
-      · have h_CAB : noncollinear C A B := by
-          simp [noncollinear]
-          have : triSet C A B = triSet A B C := by
-            ext x; simp [triSet]; tauto
-          rw [this]
-          exact hABC
-        have h_CAD : noncollinear C A D := by
-          simp [noncollinear]
-          have : triSet C A D = triSet A C D := by
-            ext x; simp [triSet]; tauto
-          rw [this]
-          exact hACD
-        have h_CBD : noncollinear C B D := by
-          simp [noncollinear]
-          have : triSet C B D = triSet B C D := by
-            ext x; simp [triSet]; tauto
-          rw [this]
-          exact hBCD
-
-        exact this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD h_CAB h_CAD h_CBD hABD hC
-    rcases (noncollinear_incidence ℓ hABC) with (hA | hBC )
+  · rcases (noncollinear_incidence ℓ hABC) with (hA | hB | hC)
     · contradiction
-    · exact hBC
+    · have h_bad: noncollinear B A D := by
+        simp [noncollinear]
+        have : triSet B A D = triSet A B D := by
+          ext x; simp [triSet]; tauto
+        rw [this]
+        exact hABD
+      have h_BAC : noncollinear B A C := by
+        simp [noncollinear]
+        have : triSet B A C = triSet A B C := by
+          ext x; simp [triSet]; tauto
+        rw [this]
+        exact hABC
 
-  obtain ⟨mB, hmB, hmB1⟩ := hP1 hAB
-  obtain ⟨mC, hmC, hmC1⟩ := hP1 hAC
-  obtain ⟨mD, hmD, hmD1⟩ := hP1 hAD
+      apply this ℓ hP1 hP2 B A C D hAB.symm hBC hBD hAC hAD hCD h_BAC h_bad hBCD hACD hB
+    · have h_CAB : noncollinear C A B := by
+        simp [noncollinear]
+        have : triSet C A B = triSet A B C := by
+          ext x; simp [triSet]; tauto
+        rw [this]
+        exact hABC
+      have h_CAD : noncollinear C A D := by
+        simp [noncollinear]
+        have : triSet C A D = triSet A C D := by
+          ext x; simp [triSet]; tauto
+        rw [this]
+        exact hACD
+      have h_CBD : noncollinear C B D := by
+        simp [noncollinear]
+        have : triSet C B D = triSet B C D := by
+          ext x; simp [triSet]; tauto
+        rw [this]
+        exact hBCD
+
+      exact this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD h_CAB h_CAD h_CBD hABD hC
+
+  obtain ⟨mB, ⟨hAmB, hBmB⟩, hmB1⟩ := hP1 hAB
+  obtain ⟨mC, ⟨hAmC, hCmC⟩, hmC1⟩ := hP1 hAC
+  obtain ⟨mD, ⟨hAmD, hDmD⟩, hmD1⟩ := hP1 hAD
   have : mB ≠ ℓ := by
-    intro h_eq
-    subst h_eq
-    exact h_not_A hmB.1
-  obtain ⟨PB, hPB, hPB1⟩ := hP2 this
+    intro h_eq; subst h_eq
+    exact h_not_A hAmB
+  obtain ⟨PB, ⟨hPBmB, hPBℓ⟩ , hPB1⟩ := hP2 this
   have : mC ≠ ℓ := by
-    intro h_eq
-    subst h_eq
-    exact h_not_A hmC.1
-  obtain ⟨PC, hPC, hPC1⟩ := hP2 this
+    intro h_eq; subst h_eq
+    exact h_not_A hAmC
+  obtain ⟨PC, ⟨hPCmC, hPCℓ⟩, hPC1⟩ := hP2 this
   have : mD ≠ ℓ := by
-    intro h_eq
-    subst h_eq
-    exact h_not_A hmD.1
-  obtain ⟨PD, hPD, hPD1⟩ := hP2 this
+    intro h_eq; subst h_eq
+    exact h_not_A hAmD
+  obtain ⟨PD, ⟨hPDmD, hPDℓ⟩, hPD1⟩ := hP2 this
   use PB, PC, PD
   simp [noncollinear, triSet, collinear] at *
   have hA_ne_PB : A ≠ PB := by
-    intro h
-    subst h
-    have : G.incidence A ℓ := hPB.2
-    exact (h_not_A this).elim
+    intro h; subst h
+    contradiction
 
   have hA_ne_PC : A ≠ PC := by
-    intro h
-    subst h
-    have : G.incidence A ℓ := hPC.2
-    exact (h_not_A this).elim
+    intro h; subst h
+    contradiction
 
   have hA_ne_PD : A ≠ PD := by
-    intro h
-    subst h
-    have : G.incidence A ℓ := hPD.2
-    exact (h_not_A this).elim
+    intro h; subst h
+    contradiction
 
   have hPB_PC : PB ≠ PC := by
     intro h_eq
     subst h_eq
-    have hPBmC : G.incidence PB mC := hPC.1
     obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
-    have hmB_eq : mB = l := huniq mB ⟨hmB.1, hPB.1⟩
-    have hmC_eq : mC = l := huniq mC ⟨hmC.1, hPC.1⟩
-    have hC_on_mB : G.incidence C mB := by
-      have h: G.incidence C mC := hmC.2
+    have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
+    have hmC_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
+    have hCmB : G.incidence C mB := by
       subst hmC_eq; subst hmB_eq
-      exact h
+      exact hCmC
     exfalso
-    apply hABC mB hmB.1 hmB.2 hC_on_mB
+    exact hABC mB hAmB hBmB hCmB
 
   have hPB_PD : PB ≠ PD := by
-    intro h_eq
-    subst h_eq
-    have hPBmD : G.incidence PB mD := hPD.1
+    intro h_eq; subst h_eq
     obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
-    have hmB_eq : mB = l := huniq mB ⟨hmB.1, hPB.1⟩
-    have hmC_eq : mD = l := huniq mD ⟨hmD.1, hPD.1⟩
-    have hD_on_mB : G.incidence D mB := by
-      have h: G.incidence D mD := hmD.2
+    have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
+    have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
+    have hDmb : G.incidence D mB := by
       subst hmC_eq; subst hmB_eq
-      exact h
+      exact hDmD
     exfalso
-    apply hABD mB hmB.1 hmB.2 hD_on_mB
+    apply hABD mB hAmB hBmB hDmb
 
   have hPC_PD : PC ≠ PD := by
     intro h_eq; subst h_eq
-    have hPCmD : G.incidence PC mD := hPD.1
     obtain ⟨l, ⟨hAl, hPCl⟩, huniq⟩ := hP1 hA_ne_PC
-    have hmB_eq : mC = l := huniq mC ⟨hmC.1, hPC.1⟩
-    have hmC_eq : mD = l := huniq mD ⟨hmD.1, hPD.1⟩
-    have hD_on_mC : G.incidence D mC := by
-      have h: G.incidence D mD := hmD.2
+    have hmB_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
+    have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
+    have hDmC : G.incidence D mC := by
       subst hmC_eq; subst hmB_eq
-      exact h
+      exact hDmD
     exfalso
-    apply hACD mC hmC.1 hmC.2 hD_on_mC
+    apply hACD mC hAmC hCmC hDmC
 
-  exact ⟨hPB_PC, hPB_PD, hPC_PD, hPB.2, hPC.2, hPD.2⟩
+  exact ⟨hPB_PC, hPB_PD, hPC_PD, hPBℓ, hPCℓ, hPDℓ⟩
 
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -103,8 +103,7 @@ lemma point_eq_of_incident
     hℓm hPℓ hPm hQℓ hQm
 
 lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
-    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ P) (hA_ne_P : A ≠ Q)
-    {mB mC : G.Line}
+    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ P) {mB mC : G.Line}
     (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (hAmC : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
     (hPBmB : P ∈ᵢ mB) (hPCmC : Q ∈ᵢ mC) : P ≠ Q := by
   rintro rfl

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -109,6 +109,18 @@ lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
   simp [noncollinear, triSet, collinear] at hABC
   apply hABC mB <;> assumption
 
+lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hBD : B ≠ D) (ℓAB_ne_ℓBD : ℓAB ≠ ℓBD)
+    (ℓBD_ne_ℓCD : ℓBD ≠ ℓCD) (hBℓAB : B ∈ᵢ ℓAB) (hBℓBD : B ∈ᵢ ℓBD) (hDℓCD : D ∈ᵢ ℓCD)
+    (hDℓBD : D ∈ᵢ ℓBD) : noncollinear (G:= G.dual) ℓAB ℓBD ℓCD := by
+  suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
+    simpa [noncollinear, collinear, triSet] using h_no_common
+  intro ⟨P, hPAB, hPBD, hPCD⟩
+  apply hBD
+  have hPA : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hBℓAB hBℓBD
+  have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hDℓBD hDℓCD
+  show B = D
+  trans P <;> (first | exact hPA.symm | exact hPB)
+
 lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
     (ℓ : G.Line):
     ∃ p q r : G.Point,
@@ -184,41 +196,14 @@ lemma P3'_dual_of_P3'
      ?nclℓABℓACℓBD, ?nclℓABℓACℓCD,
      ?nclℓABℓBDℓCD, ?nclℓACℓBDℓCD⟩
 
-  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓBD by
-      simpa [noncollinear, collinear, triSet] using h_no_common
-    intro ⟨P, hPAB, hPAC, hPBD⟩
-    apply hAB
-    have hPA : P = A := point_eq_of_incident hP2 ℓAB_ne_ℓAC hPAB hPAC hAℓAB.1 hAℓAC.1
-    have hPB : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hAℓAB.2 hBℓBD.1
-    show A = B
-    trans P <;> (first | exact hPA.symm | exact hPB)
-
-  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓCD by
-      simpa [noncollinear, collinear, triSet] using h_no_common
-    intro ⟨P, hPAB, hPAC, hPCD⟩
-    apply hAC
-    have hPA : P = A := point_eq_of_incident hP2 ℓAB_ne_ℓAC hPAB hPAC hAℓAB.1 hAℓAC.1
-    have hPB : P = C := point_eq_of_incident hP2 ℓAC_ne_ℓCD hPAC hPCD hAℓAC.2 hCℓCD.1
-    show A = C
-    trans P <;> (first | exact hPA.symm | exact hPB)
-
-  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
-      simpa [noncollinear, collinear, triSet] using h_no_common
-    intro ⟨P, hPAB, hPBD, hPCD⟩
-    apply hBD
-    have hPA : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hAℓAB.2 hBℓBD.1
-    have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hBℓBD.2 hCℓCD.2
-    show B = D
-    trans P <;> (first | exact hPA.symm | exact hPB)
-
-  · suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAC ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
-      simpa [noncollinear, collinear, triSet] using h_no_common
-    intro ⟨P, hPAC, hPBD, hPCD⟩
-    apply hCD
-    have hPA : P = C := point_eq_of_incident hP2 ℓAC_ne_ℓCD hPAC hPCD hAℓAC.2 hCℓCD.1
-    have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hBℓBD.2 hCℓCD.2
-    show C = D
-    trans P <;> (first | exact hPA.symm | exact hPB)
+  · suffices noncollinear ℓAC ℓAB ℓBD by
+      simpa [noncollinear, triSet, collinear] using this
+    exact nonconcurrent_chain hP2 hAB ℓAB_ne_ℓAC.symm ℓAB_ne_ℓBD hAℓAC.1 hAℓAB.1 hBℓBD.1 hAℓAB.2
+  · exact nonconcurrent_chain hP2 hAC ℓAB_ne_ℓAC ℓAC_ne_ℓCD hAℓAB.1 hAℓAC.1 hCℓCD.1 hAℓAC.2
+  · exact nonconcurrent_chain hP2 hBD ℓAB_ne_ℓBD ℓBD_ne_ℓCD hAℓAB.2 hBℓBD.1 hCℓCD.2 hBℓBD.2
+  · suffices noncollinear ℓAC ℓCD ℓBD  by
+      simpa [noncollinear, collinear, triSet] using this
+    exact nonconcurrent_chain hP2 hCD ℓAC_ne_ℓCD ℓBD_ne_ℓCD.symm hAℓAC.2 hCℓCD.1 hBℓBD.2 hCℓCD.2
 
 
 lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -78,6 +78,14 @@ lemma noncollinear_incidence (ℓ : G.Line) :
   -- The following tauto is _classical_
   simp at h; tauto
 
+@[simp]
+lemma noncollinear₁₂ {A B C : G.Point} : noncollinear A B C ↔ noncollinear B A C := by
+  simp [noncollinear, triSet, collinear]
+  tauto
+
+lemma noncollinear₃₁₂ {A B C : G.Point} : noncollinear C A B ↔ noncollinear A B C := by
+  simp [noncollinear, triSet, collinear]
+  tauto
 
 def P3' : Prop :=
   ∃ A B C D : G.Point,
@@ -112,39 +120,12 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
   wlog h_not_A : ¬ G.incidence A ℓ generalizing A B C D hABC hABD hACD hBCD
   · rcases (noncollinear_incidence ℓ hABC) with _ | _ | _
     · contradiction
-    · have h_bad: noncollinear B A D := by
-        simp [noncollinear]
-        have : triSet B A D = triSet A B D := by
-          ext x; simp [triSet]; tauto
-        rw [this]
-        exact hABD
-      have h_BAC : noncollinear B A C := by
-        simp [noncollinear]
-        have : triSet B A C = triSet A B C := by
-          ext x; simp [triSet]; tauto
-        rw [this]
-        exact hABC
-
+    · have hBAD : noncollinear B A D := by simp [hABD]
+      have hBAC : noncollinear B A C := by simp [hABC]
       apply this B A C D hAB.symm <;> assumption
-    · have h_CAB : noncollinear C A B := by
-        simp [noncollinear]
-        have : triSet C A B = triSet A B C := by
-          ext x; simp [triSet]; tauto
-        rw [this]
-        exact hABC
-      have h_CAD : noncollinear C A D := by
-        simp [noncollinear]
-        have : triSet C A D = triSet A C D := by
-          ext x; simp [triSet]; tauto
-        rw [this]
-        exact hACD
-      have h_CBD : noncollinear C B D := by
-        simp [noncollinear]
-        have : triSet C B D = triSet B C D := by
-          ext x; simp [triSet]; tauto
-        rw [this]
-        exact hBCD
-
+    · have hCAB : noncollinear C A B := by simp only [noncollinear₃₁₂, hABC]
+      have hCAD : noncollinear C A D := by simp [hACD]
+      have hCBD : noncollinear C B D := by simp [hBCD]
       apply this C A B D hAC.symm hBC.symm <;> assumption
 
   obtain ⟨mB, ⟨hAmB, hBmB⟩, _⟩ := hP1 hAB

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -279,40 +279,132 @@ lemma two_distinct_lines (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G)): ∃ ℓ m 
   rintro rfl; contradiction
 
 
-lemma P3'_of_P3'' (hP1   : P1 (G := G)) (hP2   : P2 (G := G)) (hP3'' : P3'' (G := G)) :
+lemma P3'_of_P3''
+    (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3'' : P3'' (G := G)) :
     P3' (G := G) := by
-  obtain ⟨ℓ, m, hℓm⟩ := two_distinct_lines hP1 hP3''
-  obtain ⟨B, ⟨hBℓ, hBm⟩, _⟩ := hP2 hℓm
+  obtain ⟨ℓ, m, hℓm⟩ := two_distinct_lines (G := G) hP1 hP3''
+  obtain ⟨B, ⟨hBℓ, hBm⟩, hBuniq⟩ := hP2 hℓm
 
   rcases hP3''.2 ℓ m with ⟨A, hAℓ, hAm⟩
-  have hAB : A ≠ B := by rintro rfl; contradiction
+  have hAB : A ≠ B := by rintro rfl; exact hAℓ hBℓ
+
   obtain ⟨n, ⟨hAn, hBn⟩, huniq_n⟩ := hP1 hAB
 
-  rcases hP3''.2 ℓ n with ⟨C, hCℓ, hCn⟩
-  have hAC : A ≠ C := by rintro rfl; contradiction
-  have hBC : B ≠ C := by rintro rfl; contradiction
+  rcases hP3''.2 n n with ⟨Q₁, hQ₁n, _⟩
+  have hAQ₁ : A ≠ Q₁ := by rintro rfl; exact hQ₁n hAn
+  obtain ⟨r, ⟨hAr, hQ₁r⟩, huniq_r⟩ := hP1 hAQ₁
+  have hr_ne_n : r ≠ n := by
+    intro h
+    have : Q₁ ∈ᵢ n := by
+      exact by cases h; exact hQ₁r
+    exact hQ₁n this
 
-  obtain ⟨nAC, ⟨hA_nAC, hC_nAC⟩, _⟩ := hP1 hAC
-  obtain ⟨nBC, ⟨hB_nBC, hC_nBC⟩, _⟩ := hP1 hBC
+  rcases hP3''.2 n r with ⟨Q₂, hQ₂n, hQ₂r⟩
+  have hAQ₂ : A ≠ Q₂ := by
+    intro h; subst h; exact hQ₂n hAn
+  obtain ⟨s, ⟨hAs, hQ₂s⟩, huniq_s⟩ := hP1 hAQ₂
+  have hs_ne_n : s ≠ n := by
+    intro h
+    have : Q₂ ∈ᵢ n := by
+      have : Q₂ ∈ᵢ s := hQ₂s
+      exact by cases h; exact this
+    exact hQ₂n this
+  have hs_ne_r : s ≠ r := by
+    intro h
+    have : Q₂ ∈ᵢ r := by
+      have : Q₂ ∈ᵢ s := hQ₂s
+      cases h; exact this
+    exact hQ₂r this
 
-  rcases hP3''.2 nAC nBC with ⟨D, hD_nAC, hD_nBC⟩
-  have hAD : A ≠ D := by rintro rfl; contradiction
-  have hBD : B ≠ D := by rintro rfl; contradiction
-  have hCD : C ≠ D := by rintro rfl; contradiction
-  refine
+  have hr_ne_ℓ : r ≠ ℓ := by
+    intro h
+    have : A ∈ᵢ ℓ := by
+      have : A ∈ᵢ r := hAr
+      cases h; exact this
+    exact hAℓ this
+  obtain ⟨C, ⟨hCr, hCℓ⟩, hCuniq⟩ := hP2 hr_ne_ℓ
+
+  have hs_ne_m : s ≠ m := by
+    intro h
+    have : A ∈ᵢ m := by
+      have : A ∈ᵢ s := hAs
+      cases h; exact this
+    exact hAm this
+  obtain ⟨D, ⟨hDs, hDm⟩, hDuniq⟩ := hP2 hs_ne_m
+
+  -- basic distinctness
+  have hAC : A ≠ C := by
+    intro h; subst h; exact hAℓ hCℓ
+  have hAD : A ≠ D := by
+    intro h; subst h; exact hAm hDm
+
+  have hBr : ¬ B ∈ᵢ r := by
+    intro hB_r
+    have : r = n :=
+      line_eq_of_point_eq (G := G) (hP1 := hP1)
+        (A := A) (P := B) (ℓ := r) (m := n) hAB hAr hB_r hAn hBn
+    exact hr_ne_n this
+  have hBs : ¬ B ∈ᵢ s := by
+    intro hB_s
+    have : s = n :=
+      line_eq_of_point_eq (G := G) (hP1 := hP1)
+        (A := A) (P := B) (ℓ := s) (m := n) hAB hAs hB_s hAn hBn
+    exact hs_ne_n this
+
+  have hBC : B ≠ C := by
+    intro h; subst h; exact hBr hCr
+  have hBD : B ≠ D := by
+    intro h; subst h; exact hBs hDs
+
+  have hCD : C ≠ D := by
+    rintro rfl
+    have : C = B := hBuniq C ⟨hCℓ, hDm⟩
+    subst C; exact hBr hCr
+
+  -- show C ∉ n
+  have hCnotn : ¬ C ∈ᵢ n := by
+    intro hCn
+    have : r = n :=
+      line_eq_of_point_eq (G := G) (hP1 := hP1)
+        (A := A) (P := C) (ℓ := r) (m := n) hAC hAr hCr hAn hCn
+    exact hr_ne_n this
+
+  -- show D ∉ n
+  have hDnotn : ¬ D ∈ᵢ n := by
+    intro hDn
+    have : s = n :=
+      line_eq_of_point_eq (G := G) (hP1 := hP1)
+        (A := A) (P := D) (ℓ := s) (m := n) hAD hAs hDs hAn hDn
+    exact hs_ne_n this
+
+  -- show D ∉ r and D ∉ ℓ
+  have hDnotr : ¬ D ∈ᵢ r := by
+    intro hDr; apply hs_ne_r.symm
+    show r = s
+    exact
+      line_eq_of_point_eq (G := G) (hP1 := hP1)
+        (A := A) (P := D) (ℓ := r) (m := s) hAD hAr hDr hAs hDs
+  have hDnotℓ : ¬ D ∈ᵢ ℓ := by
+    intro hDℓ
+    have hDB : D = B := hBuniq D ⟨hDℓ, hDm⟩
+    have : B ∈ᵢ n := hBn
+    have : D ∈ᵢ n := by cases hDB; exact this
+    exact hDnotn this
+
+  -- assemble the four noncollinearities via the helper lemma
+  have hABC : noncollinear (G := G) A B C :=
+    noncollinear_of_line_through_AB_not_C (G := G) hP1 hAB hAn hBn hCnotn
+  have hABD : noncollinear (G := G) A B D :=
+    noncollinear_of_line_through_AB_not_C (G := G) hP1 hAB hAn hBn hDnotn
+  have hACD : noncollinear (G := G) A C D := by
+    exact noncollinear_of_line_through_AB_not_C (G := G) hP1 hAC hAr hCr hDnotr
+  have hBCD : noncollinear (G := G) B C D := by
+    exact noncollinear_of_line_through_AB_not_C (G := G) hP1 hBC hBℓ hCℓ hDnotℓ
+
+  exact
     ⟨A, B, C, D,
      hAB, hAC, hAD, hBC, hBD, hCD,
-     ?hABC, ?hABD, ?hACD, ?hBCD⟩
-
-  · show noncollinear A B C
-    exact noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hCn
-  · show noncollinear A B D
-    refine noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn ?_
-    sorry
-  · show noncollinear A C D
-    exact noncollinear_of_line_through_AB_not_C hP1 hAC hA_nAC hC_nAC hD_nAC
-  · show noncollinear B C D
-    exact noncollinear_of_line_through_AB_not_C hP1 hBC hB_nBC hC_nBC hD_nBC
+     hABC, hABD, hACD, hBCD⟩
 
 
 end FromP3''

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -7,11 +7,11 @@ variable {G : IncidenceGeometry}
 
 @[reducible] def P1 : Prop :=
   ∀ {p q : G.Point}, p ≠ q →
-    ∃! ℓ : G.Line, G.incidence p ℓ ∧ G.incidence q ℓ
+    ∃! ℓ : G.Line, p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ
 
 @[reducible] def P2 : Prop :=
   ∀ {ℓ m : G.Line}, ℓ ≠ m →
-    ∃! p : G.Point, G.incidence p ℓ ∧ G.incidence p m
+    ∃! p : G.Point, p ∈ᵢ ℓ ∧ p ∈ᵢ m
 
 end ProjectivePrereqs
 
@@ -22,12 +22,12 @@ class ProjectivePlane (G : IncidenceGeometry) : Prop where
     ∀ ℓ : G.Line,
       ∃ p q r : G.Point,
         p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-        G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ
+        p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ
   P4 :
     ∀ p : G.Point,
       ∃ ℓ m n : G.Line,
         ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧
-        G.incidence p ℓ ∧ G.incidence p m ∧ G.incidence p n
+        p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n
 
 
 instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : ProjectivePlane G.dual where
@@ -47,7 +47,7 @@ def noncollinear (a b c : G.Point) : Prop :=
   ¬ IncidenceGeometry.collinear (triSet a b c)
 
 lemma noncollinear_incidence (ℓ : G.Line) :
-  noncollinear A B C → ¬G.incidence A ℓ ∨ ¬G.incidence B ℓ ∨ ¬G.incidence C ℓ := by
+  noncollinear A B C → ¬A ∈ᵢ ℓ ∨ ¬B ∈ᵢ ℓ ∨ ¬C ∈ᵢ ℓ := by
   intro h; simp only [noncollinear, triSet, collinear, trace] at h
   push_neg at h; specialize h ℓ
   -- The following tauto is _classical_
@@ -72,7 +72,7 @@ def P3' : Prop :=
     noncollinear B C D
 
 def P3'' : Prop :=
-  (∃ p ℓ, G.incidence p ℓ) ∧ ∀ ℓ m, ∃ p, ¬ G.incidence p ℓ ∧ ¬ G.incidence p m
+  (∃ p ℓ, G.incidence p ℓ) ∧ ∀ ℓ m : G.Line, ∃ p, ¬ p ∈ᵢ ℓ ∧ ¬ p ∈ᵢ m
 
 end AlternativeAxioms
 
@@ -83,8 +83,7 @@ variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
 lemma line_eq_of_point_eq
     (hP1 : P1 (G := G)) {A P : G.Point} (hA_ne_P : A ≠ P) {ℓ m : G.Line}
-    (hAℓ : G.incidence A ℓ) (hPℓ : G.incidence P ℓ)
-    (hAm : G.incidence A m) (hPm : G.incidence P m) : ℓ = m := by
+    (hAℓ : A ∈ᵢ ℓ) (hPℓ : P ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hPm : P ∈ᵢ m) : ℓ = m := by
   obtain ⟨l, _, huniq⟩ := hP1 hA_ne_P
   have hℓ : ℓ = l := huniq ℓ ⟨hAℓ, hPℓ⟩
   have hm : m = l := huniq m ⟨hAm, hPm⟩
@@ -92,12 +91,11 @@ lemma line_eq_of_point_eq
   · exact hℓ
   · exact hm.symm
 
-lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C PB PC : G.Point}
-    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ PB) (hA_ne_PC : A ≠ PC)
+lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
+    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ P) (hA_ne_P : A ≠ Q)
     {mB mC : G.Line}
-    (hAmB : G.incidence A mB) (hBmB : G.incidence B mB)
-    (hAmC : G.incidence A mC) (hCmC : G.incidence C mC)
-    (hPBmB : G.incidence PB mB) (hPCmC : G.incidence PC mC) : PB ≠ PC := by
+    (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (hAmC : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
+    (hPBmB : P ∈ᵢ mB) (hPCmC : Q ∈ᵢ mC) : P ≠ Q := by
   rintro rfl
   have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_PB <;> assumption
   subst hm_eq
@@ -108,12 +106,12 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
     (hP3' : P3' (G := G)) :
     ∃ p q r : G.Point,
       p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-      G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
+      p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
   rcases hP3' with
     ⟨A,B,C,D,
      hAB,hAC,hAD,hBC,hBD,hCD,
      hABC,hABD,hACD,hBCD⟩
-  wlog h_not_A : ¬ G.incidence A ℓ generalizing A B C D hABC hABD hACD hBCD
+  wlog h_not_A : ¬ A ∈ᵢ ℓ generalizing A B C D hABC hABD hACD hBCD
   · rcases (noncollinear_incidence ℓ hABC) with _ | _ | _
     · contradiction
     · have hBAD : noncollinear B A D := by simp [hABD]
@@ -136,19 +134,19 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
 
   use PB, PC, PD
 
-  have hA_ne_PB : A ≠ PB := by rintro rfl; contradiction
-  have hA_ne_PC : A ≠ PC := by rintro rfl; contradiction
-  have hA_ne_PD : A ≠ PD := by rintro rfl; contradiction
+  have : A ≠ PB := by rintro rfl; contradiction
+  have : A ≠ PC := by rintro rfl; contradiction
+  have : A ≠ PD := by rintro rfl; contradiction
 
   refine ⟨?_, ?_, ?_, hPBℓ, hPCℓ, hPDℓ⟩
   · show PB ≠ PC
-    apply points_distinct_of_noncollinear hP1 (PB:=PB) (PC:=PC) (mB:=mB) (mC:=mC) hABC
+    apply points_distinct_of_noncollinear hP1 (P:=PB) (Q:=PC) (mB:=mB) (mC:=mC) hABC
     <;> assumption
   · show PB ≠ PD
-    apply points_distinct_of_noncollinear hP1 (PB:=PB) (PC:=PD) (mB:=mB) (mC:=mD) hABD
+    apply points_distinct_of_noncollinear hP1 (P:=PB) (Q:=PD) (mB:=mB) (mC:=mD) hABD
     <;> assumption
   · show PC ≠ PD
-    apply points_distinct_of_noncollinear hP1 (PB:=PC) (PC:=PD) (mB:=mC) (mC:=mD) hACD
+    apply points_distinct_of_noncollinear hP1 (P:=PC) (Q:=PD) (mB:=mC) (mC:=mD) hACD
     <;> assumption
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -98,15 +98,6 @@ open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
-lemma line_unique
-    (hP1 : P1 (G := G))
-    {p q : G.Point} (hpq : p ≠ q) {ℓ₁ ℓ₂ : G.Line}
-    (hp₁ : G.incidence p ℓ₁) (hq₁ : G.incidence q ℓ₁)
-    (hp₂ : G.incidence p ℓ₂) (hq₂ : G.incidence q ℓ₂) : ℓ₁ = ℓ₂ := by
-  rcases hP1 hpq with ⟨ℓ₀, hinc₀, huniq₀⟩
-  have h₁ : ℓ₁ = ℓ₀ := huniq₀ ℓ₁ ⟨hp₁, hq₁⟩
-  have h₂ : ℓ₂ = ℓ₀ := huniq₀ ℓ₂ ⟨hp₂, hq₂⟩
-  cc
 
 
 lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G))
@@ -118,8 +109,8 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
     ⟨A,B,C,D,
      hAB,hAC,hAD,hBC,hBD,hCD,
      hABC,hABD,hACD,hBCD⟩
-  wlog h_not_A : ¬ G.incidence A ℓ
-  · rcases (noncollinear_incidence ℓ hABC) with (hA | hB | hC)
+  wlog h_not_A : ¬ G.incidence A ℓ generalizing A B C D hABC hABD hACD hBCD
+  · rcases (noncollinear_incidence ℓ hABC) with _ | _ | _
     · contradiction
     · have h_bad: noncollinear B A D := by
         simp [noncollinear]
@@ -134,7 +125,7 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
         rw [this]
         exact hABC
 
-      apply this ℓ hP1 hP2 B A C D hAB.symm hBC hBD hAC hAD hCD h_BAC h_bad hBCD hACD hB
+      apply this B A C D hAB.symm <;> assumption
     · have h_CAB : noncollinear C A B := by
         simp [noncollinear]
         have : triSet C A B = triSet A B C := by
@@ -154,70 +145,46 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
         rw [this]
         exact hBCD
 
-      exact this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD h_CAB h_CAD h_CBD hABD hC
+      apply this C A B D hAC.symm hBC.symm <;> assumption
 
-  obtain ⟨mB, ⟨hAmB, hBmB⟩, hmB1⟩ := hP1 hAB
-  obtain ⟨mC, ⟨hAmC, hCmC⟩, hmC1⟩ := hP1 hAC
-  obtain ⟨mD, ⟨hAmD, hDmD⟩, hmD1⟩ := hP1 hAD
-  have : mB ≠ ℓ := by
-    intro h_eq; subst h_eq
-    exact h_not_A hAmB
-  obtain ⟨PB, ⟨hPBmB, hPBℓ⟩ , hPB1⟩ := hP2 this
-  have : mC ≠ ℓ := by
-    intro h_eq; subst h_eq
-    exact h_not_A hAmC
-  obtain ⟨PC, ⟨hPCmC, hPCℓ⟩, hPC1⟩ := hP2 this
-  have : mD ≠ ℓ := by
-    intro h_eq; subst h_eq
-    exact h_not_A hAmD
-  obtain ⟨PD, ⟨hPDmD, hPDℓ⟩, hPD1⟩ := hP2 this
+  obtain ⟨mB, ⟨hAmB, hBmB⟩, _⟩ := hP1 hAB
+  obtain ⟨mC, ⟨hAmC, hCmC⟩, _⟩ := hP1 hAC
+  obtain ⟨mD, ⟨hAmD, hDmD⟩, _⟩ := hP1 hAD
+  have : mB ≠ ℓ := by rintro rfl; contradiction
+  obtain ⟨PB, ⟨hPBmB, hPBℓ⟩ , _⟩ := hP2 this
+  have : mC ≠ ℓ := by rintro rfl; contradiction
+  obtain ⟨PC, ⟨hPCmC, hPCℓ⟩, _⟩ := hP2 this
+  have : mD ≠ ℓ := by rintro rfl; contradiction
+  obtain ⟨PD, ⟨hPDmD, hPDℓ⟩, _⟩ := hP2 this
   use PB, PC, PD
   simp [noncollinear, triSet, collinear] at *
-  have hA_ne_PB : A ≠ PB := by
-    intro h; subst h
-    contradiction
 
-  have hA_ne_PC : A ≠ PC := by
-    intro h; subst h
-    contradiction
-
-  have hA_ne_PD : A ≠ PD := by
-    intro h; subst h
-    contradiction
+  have hA_ne_PB : A ≠ PB := by rintro rfl; contradiction
+  have hA_ne_PC : A ≠ PC := by rintro rfl; contradiction
 
   have hPB_PC : PB ≠ PC := by
-    intro h_eq
-    subst h_eq
+    rintro rfl
     obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
     have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
     have hmC_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
-    have hCmB : G.incidence C mB := by
-      subst hmC_eq; subst hmB_eq
-      exact hCmC
-    exfalso
-    exact hABC mB hAmB hBmB hCmB
+    subst hmC_eq; subst hmB_eq
+    exact hABC mB hAmB hBmB hCmC
 
   have hPB_PD : PB ≠ PD := by
-    intro h_eq; subst h_eq
+    rintro rfl
     obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
     have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
     have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
-    have hDmb : G.incidence D mB := by
-      subst hmC_eq; subst hmB_eq
-      exact hDmD
-    exfalso
-    apply hABD mB hAmB hBmB hDmb
+    subst hmC_eq; subst hmB_eq
+    exact hABD mB hAmB hBmB hDmD
 
   have hPC_PD : PC ≠ PD := by
-    intro h_eq; subst h_eq
+    rintro rfl
     obtain ⟨l, ⟨hAl, hPCl⟩, huniq⟩ := hP1 hA_ne_PC
     have hmB_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
     have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
-    have hDmC : G.incidence D mC := by
-      subst hmC_eq; subst hmB_eq
-      exact hDmD
-    exfalso
-    apply hACD mC hAmC hCmC hDmC
+    subst hmC_eq; subst hmB_eq
+    exact hACD mC hAmC hCmC hDmD
 
   exact ⟨hPB_PC, hPB_PD, hPC_PD, hPBℓ, hPCℓ, hPDℓ⟩
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -263,17 +263,14 @@ lemma P3'_of_P3'' (hP1   : P1 (G := G)) (hP2   : P2 (G := G)) (hP3'' : P3'' (G :
      hAB, hAC, hAD, hBC, hBD, hCD,
      ?hABC, ?hABD, ?hACD, ?hBCD⟩
 
-
-  -- 7. the four required non-collinearity conditions
-  have hABC : noncollinear A B C := by aesop
-  have hABD : noncollinear A B D := by aesop
-  have hACD : noncollinear A C D := by aesop
-  have hBCD : noncollinear B C D := by aesop
-
-  exact
-    ⟨A, B, C, D,
-     hAB, hAC, hAD, hBC, hBD, hCD,
-     hABC, hABD, hACD, hBCD⟩
+  · show noncollinear A B C
+    sorry
+  · show noncollinear A B D
+    sorry
+  · show noncollinear A C D
+    sorry
+  · show noncollinear B C D
+    sorry
 
 
 end FromP3''

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -78,9 +78,8 @@ def P3' : Prop :=
 def P3'' : Prop :=
   (∃ p ℓ, G.incidence p ℓ) ∧ ∀ ℓ m : G.Line, ∃ p, ¬ p ∈ᵢ ℓ ∧ ¬ p ∈ᵢ m
 
-end AlternativeAxioms
 
-namespace FromP3'
+section FromP3'
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
@@ -239,7 +238,7 @@ lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : 
 
 end FromP3'
 
-namespace FromP3''
+section FromP3''
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 
@@ -279,19 +278,18 @@ lemma P3'_of_P3'' (hP1   : P1 (G := G)) (hP2   : P2 (G := G)) (hP3'' : P3'' (G :
      ?hABC, ?hABD, ?hACD, ?hBCD⟩
 
   · show noncollinear A B C
-    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hCn
+    exact noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hCn
   · show noncollinear A B D
-    refine FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn ?_
+    refine noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn ?_
     sorry
   · show noncollinear A C D
-    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAC hA_nAC hC_nAC hD_nAC
+    exact noncollinear_of_line_through_AB_not_C hP1 hAC hA_nAC hC_nAC hD_nAC
   · show noncollinear B C D
-    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hBC hB_nBC hC_nBC hD_nBC
+    exact noncollinear_of_line_through_AB_not_C hP1 hBC hB_nBC hC_nBC hD_nBC
 
 
 end FromP3''
 
-namespace FromP3'
 open ProjectivePrereqs AlternativeAxioms
 
 theorem lemma_1_2_5 (G : IncidenceGeometry) :
@@ -326,4 +324,4 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
           P3 := hP3,
           P4 := hP4 }
 
-end FromP3'
+end AlternativeAxioms

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -99,7 +99,7 @@ open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
-lemma noncollinear_of_witness {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B)
+lemma noncollinear_of_witness' {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B)
     (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCnotℓ : ¬ C ∈ᵢ ℓ) :
     (∀ x : G.Line, A ∈ᵢ x → B ∈ᵢ x → ¬ C ∈ᵢ x) := by
   intro x hAx hBx
@@ -108,40 +108,11 @@ lemma noncollinear_of_witness {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G
   have h₂ := (line_through_unique hAB hP1 hAℓ hBℓ).symm
   exact h₁.trans h₂
 
-lemma XXX {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B) :
+lemma noncollinear_of_witness {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B) :
     A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ ¬C ∈ᵢ ℓ → noncollinear A B C := by
   rintro ⟨hAℓ, hBℓ, hC_not_ℓ⟩
-  -- simp only [noncollinear, triSet, collinear, trace]
-  simp [noncollinear, collinear, triSet]
-  intro h; simp only [noncollinear, triSet, collinear, trace] at h
-  unfold P1 at hP1
-  rcases h with ⟨m, hsubs⟩
-  have hAm : A ∈ᵢ m := by
-    exact hsubs (by
-      left; rfl)
-  have hBm : B ∈ᵢ m := by
-    exact hsubs (by
-      right; left; rfl)
-
-  rcases hP1 hAB with ⟨m₀, huniq⟩
-
-  -- 4. Identify m and ℓ with that unique line.
-  have hm_eq : m = m₀      := huniq m  ⟨hAm, hBm⟩
-  have hℓ_eq : ℓ = m₀      := (huniq ℓ ⟨hAℓ, hBℓ⟩).symm
-  have hmℓ  : m = ℓ        := by
-    trans m₀ <;> assumption
-
-  -- 5. C lies on m, hence on ℓ – contradiction.
-  have hCℓ : C ∈ᵢ ℓ := by
-    have hCm : C ∈ᵢ m := by
-      exact hsubs (by
-        right; right; rfl)
-    cases hmℓ;          -- rewrite m = ℓ
-    exact hCm
-
-  exact hC_not_ℓ hCℓ
-
-
+  simp [noncollinear, triSet, collinear]
+  exact noncollinear_of_witness' hP1 hAB hAℓ hBℓ hC_not_ℓ
 
 lemma line_eq_of_point_eq
     (hP1 : P1 (G := G)) {A P : G.Point} (hA_ne_P : A ≠ P) {ℓ m : G.Line}

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -146,32 +146,6 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
 
 
 
-/-- **Lemma 2** — every line carries three distinct points. -/
-lemma three_points_on_line (ℓ : G.Line) :
-    ∃ p q r : G.Point,
-      p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-      G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
-  rcases hP3' with
-    ⟨A,B,C,D,
-     hAB,hAC,hAD,hBC,hBD,hCD,
-     hABC,hABD,hACD,hBCD⟩
-  have casesA : G.incidence A ℓ ∨ ¬ G.incidence A ℓ := by
-    by_cases h : G.incidence A ℓ ; exact Or.inl h ; exact Or.inr h
-  have casesB : G.incidence B ℓ ∨ ¬ G.incidence B ℓ := by
-    by_cases h : G.incidence B ℓ ; exact Or.inl h ; exact Or.inr h
-  have casesC : G.incidence C ℓ ∨ ¬ G.incidence C ℓ := by
-    by_cases h : G.incidence C ℓ ; exact Or.inl h ; exact Or.inr h
-  have casesD : G.incidence D ℓ ∨ ¬ G.incidence D ℓ := by
-    by_cases h : G.incidence D ℓ ; exact Or.inl h ; exact Or.inr h
-  -- count how many of A,B,C,D lie on ℓ
-  have : (Nat.succ $ (List.filter (fun x : G.Point ↦ G.incidence x ℓ) [A,B,C,D]).length) ≥ 3 := by
-    -- tedious but straightforward enumeration of the four cases
-    decide
-  -- pick three distinct points on ℓ (build them as needed)
-  by
-    -- The constructive proof is long but routine.  `aesop` can fill it.
-    aesop
-
 /-- Packaging Lemmas 1 + 2 into the standard **P₃**, **P₄** pair. -/
 def P3_from_P3' : IncidenceGeometry :=
   let _ : P1 (G := G) := hP1

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -236,13 +236,11 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
   · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
     cases hAlt with
     | inl hP3' =>
-        let hP3 := FromP3'.three_points_on_line  hP1 hP2 hP3'
-        let hP4 := FromP3'.three_lines_through_point hP1 hP2 hP3'
         exact
         { P1 := hP1,
           P2 := hP2,
-          P3 := hP3,
-          P4 := hP4}
+          P3 := three_points_on_line  hP1 hP2 hP3',
+          P4 := three_lines_through_point hP1 hP2 hP3'}
     | inr hP3'' =>
         -- The P₃″ branch is handled dually (mirror-symmetric argument),
         -- left to the reader; `aesop` can discharge it automatically.

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -15,7 +15,7 @@ variable {G : IncidenceGeometry}
 
 end ProjectivePrereqs
 
-class ProjectivePlane (G : IncidenceGeometry.{u}) : Prop where
+class ProjectivePlane (G : IncidenceGeometry) : Prop where
   P1 : ProjectivePrereqs.P1 (G := G)
   P2 : ProjectivePrereqs.P2 (G := G)
   P3 :
@@ -71,6 +71,23 @@ def triSet (a b c : G.Point) : Set G.Point :=
 def noncollinear (a b c : G.Point) : Prop :=
   ¬ IncidenceGeometry.collinear (triSet a b c)
 
+lemma noncollinear_perm (a b c : G.Point) :
+  noncollinear a b c ↔ noncollinear b c a ∧ noncollinear c a b := by
+  simp only [noncollinear, collinear, triSet]
+  constructor
+  · rintro h
+    constructor <;> intro h' <;> push_neg at h
+    <;> obtain ⟨ℓ, hℓ⟩ := h'
+    · specialize h ℓ; simp at *
+      exact h hℓ.2.2 hℓ.1 hℓ.2.1
+    · specialize h ℓ; simp at *
+      exact h hℓ.2.1 hℓ.2.2 hℓ.1
+  · rintro ⟨h1, h2⟩
+    simp; push_neg at h1
+    intro ℓ ha hb hc
+    specialize h1 ℓ; simp at h1
+    exact h1 hb hc ha
+
 def P3' : Prop :=
   ∃ A B C D : G.Point,
     A ≠ B ∧ A ≠ C ∧ A ≠ D ∧
@@ -84,6 +101,184 @@ def P3'' : Prop :=
   (∃ p ℓ, G.incidence p ℓ) ∧ ∀ ℓ m, ∃ p, ¬ G.incidence p ℓ ∧ ¬ G.incidence p m
 
 end AlternativeAxioms
+
+namespace FromP3'
+open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
+variable {G : IncidenceGeometry}
+variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+
+lemma line_unique
+    (hP1 : P1 (G := G))
+    {p q : G.Point} (hpq : p ≠ q) {ℓ₁ ℓ₂ : G.Line}
+    (hp₁ : G.incidence p ℓ₁) (hq₁ : G.incidence q ℓ₁)
+    (hp₂ : G.incidence p ℓ₂) (hq₂ : G.incidence q ℓ₂) : ℓ₁ = ℓ₂ := by
+  rcases hP1 hpq with ⟨ℓ₀, hinc₀, huniq₀⟩
+  have h₁ : ℓ₁ = ℓ₀ := huniq₀ ℓ₁ ⟨hp₁, hq₁⟩
+  have h₂ : ℓ₂ = ℓ₀ := huniq₀ ℓ₂ ⟨hp₂, hq₂⟩
+  cc
+
+
+lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G))
+    (hP3' : P3' (G := G)) :
+    ∃ p q r : G.Point,
+      p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
+      G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
+  rcases hP3' with
+    ⟨A,B,C,D,
+     hAB,hAC,hAD,hBC,hBD,hCD,
+     hABC,hABD,hACD,hBCD⟩
+  wlog h_not_A : ¬ G.incidence A ℓ
+  · suffices h: ¬ G.incidence B ℓ ∨ ¬ G.incidence C ℓ by
+      rcases h with (hB | hC)
+      · have h_bad: noncollinear B A D := by
+          simp [noncollinear]
+          have : triSet B A D = triSet A B D := by
+            simp [triSet]; ext x; constructor <;> intro h' <;> simp
+            <;> rcases h' with rfl | rfl | rfl <;> tauto
+          rw [this]
+          exact hABD
+        have h_BAC : noncollinear B A C := by
+          simp [noncollinear]
+          have : triSet B A C = triSet A B C := by
+            simp [triSet]; ext x; constructor <;> intro h' <;> simp
+            <;> rcases h' with rfl | rfl | rfl <;> tauto
+          rw [this]
+          exact hABC
+
+        have h_BAC : noncollinear B A C := by
+          simp [noncollinear]
+          have : triSet B A C = triSet A B C := by
+            simp [triSet]; ext x; constructor <;> intro h' <;> simp
+            <;> rcases h' with rfl | rfl | rfl <;> tauto
+          rw [this]
+          exact hABC
+
+        apply this ℓ hP1 hP2 B A C D hAB.symm hBC hBD hAC hAD hCD h_BAC h_bad hBCD hACD hB
+      · apply this ℓ hP1 hP2 C A B D hAC.symm hBC.symm hCD hAB hAD hBD -- hBCD hACD hB
+
+
+
+  have h_not_A : ¬ G.incidence A ℓ := sorry
+  obtain ⟨mB, hmB, hmB1⟩ := hP1 hAB
+  obtain ⟨mC, hmC, hmC1⟩ := hP1 hAC
+  obtain ⟨mD, hmD, hmD1⟩ := hP1 hAD
+  have : mB ≠ ℓ := by
+    intro h_eq
+    subst h_eq
+    exact h_not_A hmB.1
+  obtain ⟨PB, hPB, hPB1⟩ := hP2 this
+  have : mC ≠ ℓ := by
+    intro h_eq
+    subst h_eq
+    exact h_not_A hmC.1
+  obtain ⟨PC, hPC, hPC1⟩ := hP2 this
+  have : mD ≠ ℓ := by
+    intro h_eq
+    subst h_eq
+    exact h_not_A hmD.1
+  obtain ⟨PD, hPD, hPD1⟩ := hP2 this
+  use PB, PC, PD
+  simp [noncollinear, triSet, collinear] at *
+  have hA_ne_PB : A ≠ PB := by
+    intro h
+    subst h
+    have : G.incidence A ℓ := hPB.2
+    exact (h_not_A this).elim
+
+  have hA_ne_PC : A ≠ PC := by
+    intro h
+    subst h
+    have : G.incidence A ℓ := hPC.2
+    exact (h_not_A this).elim
+
+  have hA_ne_PD : A ≠ PD := by
+    intro h
+    subst h
+    have : G.incidence A ℓ := hPD.2
+    exact (h_not_A this).elim
+
+  have hPB_PC : PB ≠ PC := by
+    intro h_eq
+    subst h_eq
+    have hPBmC : G.incidence PB mC := hPC.1
+    obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
+    have hmB_eq : mB = l := huniq mB ⟨hmB.1, hPB.1⟩
+    have hmC_eq : mC = l := huniq mC ⟨hmC.1, hPC.1⟩
+    have hC_on_mB : G.incidence C mB := by
+      have h: G.incidence C mC := hmC.2
+      subst hmC_eq; subst hmB_eq
+      exact h
+    exfalso
+    apply hABC mB hmB.1 hmB.2 hC_on_mB
+
+  have hPB_PD : PB ≠ PD := by
+    intro h_eq
+    subst h_eq
+    have hPBmD : G.incidence PB mD := hPD.1
+    obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
+    have hmB_eq : mB = l := huniq mB ⟨hmB.1, hPB.1⟩
+    have hmC_eq : mD = l := huniq mD ⟨hmD.1, hPD.1⟩
+    have hD_on_mB : G.incidence D mB := by
+      have h: G.incidence D mD := hmD.2
+      subst hmC_eq; subst hmB_eq
+      exact h
+    exfalso
+    apply hABD mB hmB.1 hmB.2 hD_on_mB
+
+  have hPC_PD : PC ≠ PD := by
+    intro h_eq; subst h_eq
+    have hPCmD : G.incidence PC mD := hPD.1
+    obtain ⟨l, ⟨hAl, hPCl⟩, huniq⟩ := hP1 hA_ne_PC
+    have hmB_eq : mC = l := huniq mC ⟨hmC.1, hPC.1⟩
+    have hmC_eq : mD = l := huniq mD ⟨hmD.1, hPD.1⟩
+    have hD_on_mC : G.incidence D mC := by
+      have h: G.incidence D mD := hmD.2
+      subst hmC_eq; subst hmB_eq
+      exact h
+    exfalso
+    apply hACD mC hmC.1 hmC.2 hD_on_mC
+
+  exact ⟨hPB_PC, hPB_PD, hPC_PD, hPB.2, hPC.2, hPD.2⟩
+
+
+
+/-- **Lemma 2** — every line carries three distinct points. -/
+lemma three_points_on_line (ℓ : G.Line) :
+    ∃ p q r : G.Point,
+      p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
+      G.incidence p ℓ ∧ G.incidence q ℓ ∧ G.incidence r ℓ := by
+  rcases hP3' with
+    ⟨A,B,C,D,
+     hAB,hAC,hAD,hBC,hBD,hCD,
+     hABC,hABD,hACD,hBCD⟩
+  have casesA : G.incidence A ℓ ∨ ¬ G.incidence A ℓ := by
+    by_cases h : G.incidence A ℓ ; exact Or.inl h ; exact Or.inr h
+  have casesB : G.incidence B ℓ ∨ ¬ G.incidence B ℓ := by
+    by_cases h : G.incidence B ℓ ; exact Or.inl h ; exact Or.inr h
+  have casesC : G.incidence C ℓ ∨ ¬ G.incidence C ℓ := by
+    by_cases h : G.incidence C ℓ ; exact Or.inl h ; exact Or.inr h
+  have casesD : G.incidence D ℓ ∨ ¬ G.incidence D ℓ := by
+    by_cases h : G.incidence D ℓ ; exact Or.inl h ; exact Or.inr h
+  -- count how many of A,B,C,D lie on ℓ
+  have : (Nat.succ $ (List.filter (fun x : G.Point ↦ G.incidence x ℓ) [A,B,C,D]).length) ≥ 3 := by
+    -- tedious but straightforward enumeration of the four cases
+    decide
+  -- pick three distinct points on ℓ (build them as needed)
+  by
+    -- The constructive proof is long but routine.  `aesop` can fill it.
+    aesop
+
+/-- Packaging Lemmas 1 + 2 into the standard **P₃**, **P₄** pair. -/
+def P3_from_P3' : IncidenceGeometry :=
+  let _ : P1 (G := G) := hP1
+  let _ : P2 (G := G) := hP2
+  have h₁ := three_lines_through_point hP1 hP2 hP3'
+  have h₂ := three_points_on_line    hP1 hP2 hP3'
+  { Point     := G.Point,
+    Line      := G.Line,
+    incidence := G.incidence }
+
+end FromP3'
 
 namespace FromP3'
 open ProjectivePrereqs AlternativeAxioms
@@ -104,7 +299,6 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
   · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
     cases hAlt with
     | inl hP3' =>
-        -- Build P₃ and P₄ from the previous section.
         let hP3 := (FromP3'.three_points_on_line  hP1 hP2 hP3')
         let hP4 := (FromP3'.three_lines_through_point hP1 hP2 hP3')
         exact

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -81,7 +81,28 @@ open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
+lemma line_eq_of_point_eq
+    (hP1 : P1 (G := G)) {A P : G.Point} (hA_ne_P : A ≠ P) {ℓ m : G.Line}
+    (hAℓ : G.incidence A ℓ) (hPℓ : G.incidence P ℓ)
+    (hAm : G.incidence A m) (hPm : G.incidence P m) : ℓ = m := by
+  obtain ⟨l, _, huniq⟩ := hP1 hA_ne_P
+  have hℓ : ℓ = l := huniq ℓ ⟨hAℓ, hPℓ⟩
+  have hm : m = l := huniq m ⟨hAm, hPm⟩
+  trans l
+  · exact hℓ
+  · exact hm.symm
 
+lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C PB PC : G.Point}
+    (hABC : noncollinear A B C) (hA_ne_PB : A ≠ PB) (hA_ne_PC : A ≠ PC)
+    {mB mC : G.Line}
+    (hAmB : G.incidence A mB) (hBmB : G.incidence B mB)
+    (hAmC : G.incidence A mC) (hCmC : G.incidence C mC)
+    (hPBmB : G.incidence PB mB) (hPCmC : G.incidence PC mC) : PB ≠ PC := by
+  rintro rfl
+  have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_PB <;> assumption
+  subst hm_eq
+  simp [noncollinear, triSet, collinear] at hABC
+  apply hABC mB <;> assumption
 
 lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G))
     (hP3' : P3' (G := G)) :
@@ -112,37 +133,23 @@ lemma three_points_on_line (ℓ : G.Line) (hP1 : P1 (G := G)) (hP2 : P2 (G := G)
   obtain ⟨PC, ⟨hPCmC, hPCℓ⟩, _⟩ := hP2 this
   have : mD ≠ ℓ := by rintro rfl; contradiction
   obtain ⟨PD, ⟨hPDmD, hPDℓ⟩, _⟩ := hP2 this
+
   use PB, PC, PD
-  simp [noncollinear, triSet, collinear] at *
 
   have hA_ne_PB : A ≠ PB := by rintro rfl; contradiction
   have hA_ne_PC : A ≠ PC := by rintro rfl; contradiction
+  have hA_ne_PD : A ≠ PD := by rintro rfl; contradiction
 
-  have hPB_PC : PB ≠ PC := by
-    rintro rfl
-    obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
-    have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
-    have hmC_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
-    subst hmC_eq; subst hmB_eq
-    exact hABC mB hAmB hBmB hCmC
-
-  have hPB_PD : PB ≠ PD := by
-    rintro rfl
-    obtain ⟨l, ⟨hAl, hPBl⟩, huniq⟩ := hP1 hA_ne_PB
-    have hmB_eq : mB = l := huniq mB ⟨hAmB, hPBmB⟩
-    have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
-    subst hmC_eq; subst hmB_eq
-    exact hABD mB hAmB hBmB hDmD
-
-  have hPC_PD : PC ≠ PD := by
-    rintro rfl
-    obtain ⟨l, ⟨hAl, hPCl⟩, huniq⟩ := hP1 hA_ne_PC
-    have hmB_eq : mC = l := huniq mC ⟨hAmC, hPCmC⟩
-    have hmC_eq : mD = l := huniq mD ⟨hAmD, hPDmD⟩
-    subst hmC_eq; subst hmB_eq
-    exact hACD mC hAmC hCmC hDmD
-
-  exact ⟨hPB_PC, hPB_PD, hPC_PD, hPBℓ, hPCℓ, hPDℓ⟩
+  refine ⟨?_, ?_, ?_, hPBℓ, hPCℓ, hPDℓ⟩
+  · show PB ≠ PC
+    apply points_distinct_of_noncollinear hP1 (PB:=PB) (PC:=PC) (mB:=mB) (mC:=mC) hABC
+    <;> assumption
+  · show PB ≠ PD
+    apply points_distinct_of_noncollinear hP1 (PB:=PB) (PC:=PD) (mB:=mB) (mC:=mD) hABD
+    <;> assumption
+  · show PC ≠ PD
+    apply points_distinct_of_noncollinear hP1 (PB:=PC) (PC:=PD) (mB:=mC) (mC:=mD) hACD
+    <;> assumption
 
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -161,7 +161,7 @@ variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 lemma line_ne_of_noncollinear
     (hABC  : noncollinear A B C) (hAℓ  : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCm : C ∈ᵢ m) : ℓ ≠ m := by
   rintro rfl
-  apply hABC; use ℓ; simp [collinear, triSet]
+  apply hABC; simp [collinear, triSet]; use ℓ
   exact ⟨hAℓ, hBℓ, hCm⟩
 
 lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {P Q : G.Point}
@@ -283,8 +283,8 @@ lemma P3'_dual_of_P3'
     exact nonconcurrent_chain hP2 hCD ℓAC_ne_ℓCD ℓBD_ne_ℓCD.symm hAℓAC.2 hCℓCD.1 hBℓBD.2 hCℓCD.2
 
 
-lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G)) (A : G.Point) :
-  ∃ ℓ m n : G.Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ A ∈ᵢ ℓ ∧ A ∈ᵢ m ∧ A ∈ᵢ n :=
+lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
+    (A : G.Point) : ∃ ℓ m n : G.Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ A ∈ᵢ ℓ ∧ A ∈ᵢ m ∧ A ∈ᵢ n :=
   three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') A
 
 
@@ -303,7 +303,8 @@ section FromP3''
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry} {A B C: G.Point} {ℓ m: G.Line}
 
-lemma exists_line_with_point_and_nonpoint (hP3'' : P3'' (G := G)) : ∃ ℓ : G.Line, ∃ A B, A ∈ᵢ ℓ ∧ ¬B ∈ᵢ ℓ := by
+lemma exists_line_with_point_and_nonpoint (hP3'' : P3'' (G := G)) :
+    ∃ ℓ : G.Line, ∃ A B, A ∈ᵢ ℓ ∧ ¬B ∈ᵢ ℓ := by
   rcases hP3'' with ⟨⟨A, ℓ₀, hAℓ₀⟩, hOff⟩
   rcases hOff ℓ₀ ℓ₀ with ⟨B, hBℓ₀, _⟩
   exact ⟨ℓ₀, A, B, hAℓ₀, hBℓ₀⟩
@@ -377,10 +378,8 @@ lemma P3'_of_P3''
   have hACD : noncollinear A C D := noncollinear_of_line_through_AB_not_C hP1 hAC hAr hCr hDnotr
   have hBCD : noncollinear B C D := noncollinear_of_line_through_AB_not_C hP1 hBC hBℓ hCℓ hDnotℓ
 
-  exact
-    ⟨A, B, C, D,
-     hAB, hAC, hAD, hBC, hBD, hCD,
-     hABC, hABD, hACD, hBCD⟩
+  use A, B, C, D
+
 
 
 end FromP3''
@@ -390,31 +389,90 @@ section FromProjectivePlane
 variable {G : IncidenceGeometry} [ProjectivePlane G]
 variable {ℓ m : G.Line} {A B : G.Point}
 
-lemma exists_point_ne_O_on_line
-    (O : G.Point) (ℓ : G.Line) : ∃ A : G.Point, A ∈ᵢ ℓ ∧ A ≠ O := by
-  rcases ProjectivePlane.P3 (G := G) ℓ with
-    ⟨X, Y, Z, -, _, -, hXℓ, hYℓ, hZℓ⟩
-  by_cases hX : X = O
-  · by_cases hY : Y = O
-    · have hZne : Z ≠ O := by
-        intro
-        have : X = Z := by subst Z; assumption
-        contradiction
-      exact ⟨Z, hZℓ, hZne⟩
-    · exact ⟨Y, hYℓ, hY⟩
-  · exact ⟨X, hXℓ, hX⟩
+lemma exist_points_ne_O_on_line
+    (O : G.Point) (ℓ : G.Line) : ∃ A B : G.Point, A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ A ≠ O ∧ B ≠ O ∧ A ≠ B := by
+  rcases ProjectivePlane.P3 (G := G) ℓ with ⟨X, Y, Z, _, _, _, _, _, _⟩
+  by_cases X = O
+  · by_cases Y = O
+    · subst X; subst Y; contradiction
+    · by_cases Z = O
+      · subst X; subst Z; contradiction
+      · use Y, Z
+  · by_cases Y = O
+    · by_cases Z = O
+      · subst Y; subst Z; contradiction
+      · use X, Z
+    · use X, Y
 
+-- lemma two_points_on_line_away_from_O {O : G.Point} (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
+--     ∃ A B : G.Point, A ≠ B ∧ A ∈ᵢ ℓ ∧ B ∈ᵢ m ∧ A ≠ O ∧ B ≠ O := by
+--   obtain ⟨A, hAℓ, hA_ne_O⟩ := exists_point_ne_O_on_line (G := G) O ℓ
+--   obtain ⟨B, hBm, hB_ne_O⟩ := exists_point_ne_O_on_line (G := G) O m
+--   have hAB : A ≠ B :=
+--     ne_of_distinct_lines_through_O (G := G) (hP2 := ProjectivePlane.P2 (G := G))
+--       hℓm hOℓ hOm hAℓ hBm hA_ne_O
+--   use A, B
 
+lemma P3'_of_ProjectivePlane {G : IncidenceGeometry} [ProjectivePlane G] : P3' (G := G) := by
+  obtain ⟨O⟩ := ProjectivePlane.P0 (G := G)
+  obtain ⟨ℓ, m, n, hℓm, hℓn, hmn, hOℓ, hOm, hOn⟩ := ProjectivePlane.P4 O
 
+  obtain ⟨A, B, hAℓ, hBℓ, hA_ne_O, hB_ne_O, hA_ne_B⟩ := exist_points_ne_O_on_line (G := G) O ℓ
+  obtain ⟨C, D, hCm, hDm, hC_ne_O, hD_ne_O, hC_ne_D⟩ := exist_points_ne_O_on_line (G := G) O m
 
-lemma two_points_on_line_away_from_O {O : G.Point} (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
-    ∃ A B : G.Point, A ≠ B ∧ A ∈ᵢ ℓ ∧ B ∈ᵢ m ∧ A ≠ O ∧ B ≠ O := by
-  obtain ⟨A, hAℓ, hA_ne_O⟩ := exists_point_ne_O_on_line (G := G) O ℓ
-  obtain ⟨B, hBm, hB_ne_O⟩ := exists_point_ne_O_on_line (G := G) O m
-  have hAB : A ≠ B :=
-    ne_of_distinct_lines_through_O (G := G) (hP2 := ProjectivePlane.P2 (G := G))
-      hℓm hOℓ hOm hAℓ hBm hA_ne_O
-  use A, B
+  have hP1 : P1 := ProjectivePlane.P1 (G := G)
+  have hP2 : P2 := ProjectivePlane.P2 (G := G)
+
+  have hA_ne_C : A ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hCm hA_ne_O
+  have hA_ne_D : A ≠ D := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hDm hA_ne_O
+  have hB_ne_C : B ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hBℓ hCm hB_ne_O
+  have hB_ne_D : B ≠ D := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hBℓ hDm hB_ne_O
+
+  have hAnotm : ¬ A ∈ᵢ m := not_mem_of_line_ne hP1 hA_ne_O.symm hOℓ hAℓ hOm hℓm
+  have hBnotm : ¬ B ∈ᵢ m := not_mem_of_line_ne hP1 hB_ne_O.symm hOℓ hBℓ hOm hℓm
+  have hCnotℓ : ¬ C ∈ᵢ ℓ := not_mem_of_line_ne hP1 hC_ne_O.symm hOm hCm hOℓ hℓm.symm
+  have hDnotℓ : ¬ D ∈ᵢ ℓ := not_mem_of_line_ne hP1 hD_ne_O.symm hOm hDm hOℓ hℓm.symm
+
+  have : noncollinear A B C := noncollinear_of_line_through_AB_not_C hP1 hA_ne_B hAℓ hBℓ hCnotℓ
+  have : noncollinear A B D := noncollinear_of_line_through_AB_not_C hP1 hA_ne_B hAℓ hBℓ hDnotℓ
+  have : noncollinear A C D := by
+    suffices noncollinear C D A by exact noncollinear₃₁₂.mpr this
+    exact noncollinear_of_line_through_AB_not_C hP1 hC_ne_D hCm hDm hAnotm
+  have : noncollinear B C D := by
+    suffices noncollinear C D B by exact noncollinear₃₁₂.mpr this
+    exact noncollinear_of_line_through_AB_not_C hP1 hC_ne_D hCm hDm hBnotm
+
+  use A, B, C, D
+
+  -- -- obtain ⟨A, B, hAB, hAℓ, hBm, hA_ne_O, hB_ne_O⟩ :=
+  -- --   two_points_on_line_away_from_O (G := G) hℓm hOℓ hOm
+  -- -- obtain ⟨C, D, hCD, hCℓ, hDn, hC_ne_O, hD_ne_O⟩ :=
+  -- --   two_points_on_line_away_from_O (G := G) hℓn hOℓ hOn
+  -- -- obtain ⟨E, F, hEF, hEℓ, hFn, hE_ne_O, hF_ne_O⟩ :=
+  -- --   two_points_on_line_away_from_O (G := G) hℓn hOℓ hOn
+
+  -- have hP2 : P2 := ProjectivePlane.P2 (G := G)
+
+  -- -- have hAC : A ≠ C := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hCℓ hA_ne_O
+  -- have : A ≠ B := ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hAℓ hBm hA_ne_O
+  -- have hAD : A ≠ D := ne_of_distinct_lines_through_O hP2 hℓn hOℓ hOn hAℓ hDn hA_ne_O
+  -- have hBC : B ≠ C := (ne_of_distinct_lines_through_O hP2 hℓm hOℓ hOm hCℓ hBm  hC_ne_O).symm
+  -- have hBD : B ≠ D := ne_of_distinct_lines_through_O hP2 hmn hOm hOn hBm  hDn hB_ne_O
+
+  -- -- Show the four triples are noncollinear
+  -- have hABC : noncollinear A B C := by
+  --   sorry -- A ∈ ℓ, B ∈ m, C ∈ ℓ, but ℓ ≠ m so they can't all be on one line
+
+  -- have hABD : noncollinear A B D := by
+  --   sorry -- A ∈ ℓ, B ∈ m, D ∈ n, all distinct lines
+
+  -- have hACD : noncollinear A C D := by
+  --   sorry -- A ∈ ℓ, C ∈ ℓ (but A ≠ C), D ∈ n, ℓ ≠ n
+
+  -- have hBCD : noncollinear B C D := by
+  --   sorry -- B ∈ m, C ∈ ℓ, D ∈ n, all distinct lines
+
+  -- use A, B, C, D
 
 end FromProjectivePlane
 
@@ -424,9 +482,7 @@ theorem lemma_1_2_5 (G : IncidenceGeometry) :
     ProjectivePlane G ↔ (P1 (G := G) ∧ P2 (G := G)) ∧ (P3' (G := G) ∨ P3'' (G := G)) := by
   constructor
   · intro h
-    refine ⟨⟨h.P1, h.P2⟩, ?_⟩
-    have : P3' (G := G) := by sorry
-    exact Or.inl this
+    exact ⟨⟨h.P1, h.P2⟩, Or.inl P3'_of_ProjectivePlane⟩
   · rintro ⟨⟨hP1, hP2⟩, hAlt⟩
     cases hAlt with
     | inl hP3' =>

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -108,7 +108,7 @@ lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
     (hPBmB : P ∈ᵢ mB) (hPCmC : Q ∈ᵢ mC) : P ≠ Q := by
   rintro rfl
   have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_PB <;> assumption
-  subst hm_eq
+  subst mC
   simp [noncollinear, triSet, collinear] at hABC
   apply hABC mB <;> assumption
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -223,6 +223,22 @@ lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : 
 
 end FromP3'
 
+namespace FromP3''
+open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
+variable {G : IncidenceGeometry}
+
+lemma two_distinct_lines (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G)): ∃ ℓ m : G.Line, ℓ ≠ m := by
+  rcases hP3'' with ⟨⟨p₀, ℓ₀, _⟩, hOff⟩
+  rcases hOff ℓ₀ ℓ₀ with ⟨q, hqℓ₀, _⟩
+  have hpq : p₀ ≠ q := by rintro rfl; contradiction
+  rcases hP1 hpq with ⟨m, ⟨_, hqm⟩, _⟩
+  use ℓ₀, m
+  show ℓ₀ ≠ m
+  rintro rfl; contradiction
+
+
+end FromP3''
+
 namespace FromP3'
 open ProjectivePrereqs AlternativeAxioms
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -134,12 +134,9 @@ lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) {A B C : G.Point
   intro hCol
   simp [triSet, collinear] at hCol
   rcases hCol with ⟨m, hAm, hBm, hCm⟩
-
   obtain ⟨ℓ₀, ⟨hAℓ₀, hBℓ₀⟩, huniq⟩ := hP1 hAB
-
-  have hℓ_eq : ℓ = ℓ₀ := huniq ℓ ⟨hAℓ, hBℓ⟩
-  have hm_eq : m = ℓ₀ := huniq m ⟨hAm, hBm⟩
-  subst m ℓ
+  have : ℓ = m := line_eq_of_point_eq hP1 hAB hAℓ hBℓ hAm hBm
+  subst m
   exact hC_not_ℓ hCm
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -58,6 +58,10 @@ lemma noncollinear₁₂ {A B C : G.Point} : noncollinear A B C ↔ noncollinear
   simp [noncollinear, triSet, collinear]
   tauto
 
+lemma noncollinear₂₃ {A B C : G.Point} : noncollinear A B C ↔ noncollinear A C B := by
+  simp [noncollinear, triSet, collinear]
+  tauto
+
 lemma noncollinear₃₁₂ {A B C : G.Point} : noncollinear C A B ↔ noncollinear A B C := by
   simp [noncollinear, triSet, collinear]
   tauto
@@ -109,17 +113,22 @@ lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
   simp [noncollinear, triSet, collinear] at hABC
   apply hABC mB <;> assumption
 
-lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hBD : B ≠ D) (ℓAB_ne_ℓBD : ℓAB ≠ ℓBD)
-    (ℓBD_ne_ℓCD : ℓBD ≠ ℓCD) (hBℓAB : B ∈ᵢ ℓAB) (hBℓBD : B ∈ᵢ ℓBD) (hDℓCD : D ∈ᵢ ℓCD)
-    (hDℓBD : D ∈ᵢ ℓBD) : noncollinear (G:= G.dual) ℓAB ℓBD ℓCD := by
-  suffices h_no_common : ¬ ∃ P : G.Point, P ∈ᵢ ℓAB ∧ P ∈ᵢ ℓBD ∧ P ∈ᵢ ℓCD by
+lemma line_ne_of_noncollinear {A B C : G.Point} {ℓ₁ ℓ₂ : G.Line}
+    (hABC  : noncollinear A B C) (hAℓ₁  : A ∈ᵢ ℓ₁) (hBℓ₁ : B ∈ᵢ ℓ₁) (hCℓ₂ : C ∈ᵢ ℓ₂) : ℓ₁ ≠ ℓ₂ := by
+  rintro rfl
+  apply hABC; use ℓ₁; simp [collinear, triSet]
+  exact ⟨hAℓ₁, hBℓ₁, hCℓ₂⟩
+
+lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (h₂ : m ≠ n)
+    (h₃ : P ∈ᵢ l) (h₄ : P ∈ᵢ m) (h₅ : Q ∈ᵢ n) (h₆ : Q ∈ᵢ m) : noncollinear (G:= G.dual) l m n := by
+  suffices h_no_common : ¬ ∃ A : G.Point, A ∈ᵢ l ∧ A ∈ᵢ m ∧ A ∈ᵢ n by
     simpa [noncollinear, collinear, triSet] using h_no_common
-  intro ⟨P, hPAB, hPBD, hPCD⟩
-  apply hBD
-  have hPA : P = B := point_eq_of_incident hP2 ℓAB_ne_ℓBD hPAB hPBD hBℓAB hBℓBD
-  have hPB : P = D := point_eq_of_incident hP2 ℓBD_ne_ℓCD hPBD hPCD hDℓBD hDℓCD
-  show B = D
-  trans P <;> (first | exact hPA.symm | exact hPB)
+  intro ⟨A', _, _, _⟩
+  apply hPQ
+  calc P
+    _ = A' := by symm; apply point_eq_of_incident (ℓ:= l) (m:=m) (P:=A') (Q:=P) <;> assumption
+    _ = Q := by apply point_eq_of_incident (ℓ:= m) (m:=n) (P:=A') (Q:=Q) <;> assumption
+
 
 lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
     (ℓ : G.Line):
@@ -180,14 +189,17 @@ lemma P3'_dual_of_P3'
   obtain ⟨ℓBD, hBℓBD, hDℓBD⟩ := hP1 hBD
   obtain ⟨ℓCD, hCℓCD, hDℓCD⟩ := hP1 hCD
 
-  have ℓAB_ne_ℓAC : ℓAB ≠ ℓAC := by sorry
-  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := by sorry
-  have ℓAB_ne_ℓCD : ℓAB ≠ ℓCD := by sorry
-  have ℓBD_ne_ℓCD : ℓBD ≠ ℓCD := by sorry
+  have hCDB : (noncollinear C D B) := noncollinear₃₁₂.mp hBCD
+  have hBDA : (noncollinear B D A) := noncollinear₃₁₂.mp hABD
 
-  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := sorry
-  have ℓAC_ne_ℓBD : ℓAC ≠ ℓBD := sorry
-  have ℓAC_ne_ℓCD : ℓAC ≠ ℓCD := sorry
+  have ℓAB_ne_ℓAC : ℓAB ≠ ℓAC := by apply line_ne_of_noncollinear hABC hAℓAB.1 hAℓAB.2 hAℓAC.2
+  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := by apply line_ne_of_noncollinear hABD hAℓAB.1 hAℓAB.2 hBℓBD.2
+  have ℓAB_ne_ℓCD : ℓAB ≠ ℓCD := by apply line_ne_of_noncollinear hABD hAℓAB.1 hAℓAB.2 hCℓCD.2
+  have ℓBD_ne_ℓCD : ℓBD ≠ ℓCD := by symm; apply line_ne_of_noncollinear hCDB hCℓCD.1 hCℓCD.2 hBℓBD.1
+
+  have ℓAB_ne_ℓBD : ℓAB ≠ ℓBD := by apply line_ne_of_noncollinear hABD hAℓAB.1 hAℓAB.2 hBℓBD.2
+  have ℓAC_ne_ℓBD : ℓAC ≠ ℓBD := by symm; apply line_ne_of_noncollinear hBDA hBℓBD.1 hBℓBD.2 hAℓAC.1
+  have ℓAC_ne_ℓCD : ℓAC ≠ ℓCD := by apply line_ne_of_noncollinear hACD hAℓAC.1 hAℓAC.2 hCℓCD.2
 
   refine
     ⟨ℓAB, ℓAC, ℓBD, ℓCD,
@@ -196,13 +208,13 @@ lemma P3'_dual_of_P3'
      ?nclℓABℓACℓBD, ?nclℓABℓACℓCD,
      ?nclℓABℓBDℓCD, ?nclℓACℓBDℓCD⟩
 
-  · suffices noncollinear ℓAC ℓAB ℓBD by
-      simpa [noncollinear, triSet, collinear] using this
+  · suffices noncollinear (G := G.dual) ℓAC ℓAB ℓBD by
+      simpa [noncollinear₁₂] using this
     exact nonconcurrent_chain hP2 hAB ℓAB_ne_ℓAC.symm ℓAB_ne_ℓBD hAℓAC.1 hAℓAB.1 hBℓBD.1 hAℓAB.2
   · exact nonconcurrent_chain hP2 hAC ℓAB_ne_ℓAC ℓAC_ne_ℓCD hAℓAB.1 hAℓAC.1 hCℓCD.1 hAℓAC.2
   · exact nonconcurrent_chain hP2 hBD ℓAB_ne_ℓBD ℓBD_ne_ℓCD hAℓAB.2 hBℓBD.1 hCℓCD.2 hBℓBD.2
-  · suffices noncollinear ℓAC ℓCD ℓBD  by
-      simpa [noncollinear, collinear, triSet] using this
+  · suffices noncollinear (G := G.dual) ℓAC ℓCD ℓBD  by
+      simpa [noncollinear₂₃] using this
     exact nonconcurrent_chain hP2 hCD ℓAC_ne_ℓCD ℓBD_ne_ℓCD.symm hAℓAC.2 hCℓCD.1 hBℓBD.2 hCℓCD.2
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -407,16 +407,14 @@ lemma exists_point_ne_O_on_line
 
 
 
-lemma two_points_on_line_away_from_O {O : G.Point}
-    {ℓ m : G.Line}
-    (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
+lemma two_points_on_line_away_from_O {O : G.Point} (hℓm : ℓ ≠ m) (hOℓ : O ∈ᵢ ℓ) (hOm : O ∈ᵢ m) :
     ∃ A B : G.Point, A ≠ B ∧ A ∈ᵢ ℓ ∧ B ∈ᵢ m ∧ A ≠ O ∧ B ≠ O := by
   obtain ⟨A, hAℓ, hA_ne_O⟩ := exists_point_ne_O_on_line (G := G) O ℓ
   obtain ⟨B, hBm, hB_ne_O⟩ := exists_point_ne_O_on_line (G := G) O m
   have hAB : A ≠ B :=
     ne_of_distinct_lines_through_O (G := G) (hP2 := ProjectivePlane.P2 (G := G))
       hℓm hOℓ hOm hAℓ hBm hA_ne_O
-  exact ⟨A, B, hAB, hAℓ, hBm, hA_ne_O, hB_ne_O⟩
+  use A, B
 
 end FromProjectivePlane
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -101,21 +101,21 @@ lemma point_eq_of_incident
   line_eq_of_point_eq (G := G.dual) (hP1 := hP2) (A := ℓ) (P := m) (ℓ := P) (m := Q)
     hℓm hPℓ hPm hQℓ hQm
 
-lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
-    (hABC : noncollinear A B C) (hA_ne_P : A ≠ P) {mB mC : G.Line}
-    (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (hAmC : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
-    (hPBmB : P ∈ᵢ mB) (hPCmC : Q ∈ᵢ mC) : P ≠ Q := by
-  rintro rfl
-  have hm_eq : mB = mC := by apply line_eq_of_point_eq hP1 hA_ne_P <;> assumption
-  subst mC
-  simp [noncollinear, triSet, collinear] at hABC
-  apply hABC mB <;> assumption
-
 lemma line_ne_of_noncollinear {A B C : G.Point} {ℓ₁ ℓ₂ : G.Line}
     (hABC  : noncollinear A B C) (hAℓ₁  : A ∈ᵢ ℓ₁) (hBℓ₁ : B ∈ᵢ ℓ₁) (hCℓ₂ : C ∈ᵢ ℓ₂) : ℓ₁ ≠ ℓ₂ := by
   rintro rfl
   apply hABC; use ℓ₁; simp [collinear, triSet]
   exact ⟨hAℓ₁, hBℓ₁, hCℓ₂⟩
+
+lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
+    (hABC : noncollinear A B C) (hA_ne_P : A ≠ P) {mB mC : G.Line}
+    (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (_ : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
+    (_ : P ∈ᵢ mB) (_ : Q ∈ᵢ mC) : P ≠ Q := by
+  rintro rfl
+  apply line_ne_of_noncollinear hABC hAmB hBmB hCmC
+  show mB = mC
+  apply line_eq_of_point_eq hP1 hA_ne_P <;> assumption
+
 
 
 lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (h₂ : m ≠ n)

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -130,6 +130,21 @@ lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (
     _ = Q := by apply point_eq_of_incident (ℓ:= m) (m:=n) (P:=A') (Q:=Q) <;> assumption
 
 
+lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) {A B C : G.Point} (hAB : A ≠ B)
+    {ℓ : G.Line} (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
+  intro hCol
+  simp [triSet, collinear] at hCol
+  rcases hCol with ⟨m, hAm, hBm, hCm⟩
+
+  obtain ⟨ℓ₀, ⟨hAℓ₀, hBℓ₀⟩, huniq⟩ := hP1 hAB
+
+  have hℓ_eq : ℓ = ℓ₀ := huniq ℓ ⟨hAℓ, hBℓ⟩
+  have hm_eq : m = ℓ₀ := huniq m ⟨hAm, hBm⟩
+  subst m ℓ
+  exact hC_not_ℓ hCm
+
+
+
 lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
     (ℓ : G.Line) : ∃ p q r : G.Point, p ≠ q ∧ p ≠ r ∧ q ≠ r ∧ p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
   rcases hP3' with
@@ -264,13 +279,14 @@ lemma P3'_of_P3'' (hP1   : P1 (G := G)) (hP2   : P2 (G := G)) (hP3'' : P3'' (G :
      ?hABC, ?hABD, ?hACD, ?hBCD⟩
 
   · show noncollinear A B C
-    sorry
+    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hCn
   · show noncollinear A B D
+    refine FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn ?_
     sorry
   · show noncollinear A C D
-    sorry
+    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hAC hA_nAC hC_nAC hD_nAC
   · show noncollinear B C D
-    sorry
+    exact FromP3'.noncollinear_of_line_through_AB_not_C hP1 hBC hB_nBC hC_nBC hD_nBC
 
 
 end FromP3''

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -130,10 +130,7 @@ lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (
 
 
 lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
-    (ℓ : G.Line):
-    ∃ p q r : G.Point,
-      p ≠ q ∧ p ≠ r ∧ q ≠ r ∧
-      p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
+    (ℓ : G.Line) : ∃ p q r : G.Point, p ≠ q ∧ p ≠ r ∧ q ≠ r ∧ p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
   rcases hP3' with
     ⟨A,B,C,D,
      hAB,hAC,hAD,hBC,hBD,hCD,
@@ -218,8 +215,8 @@ lemma P3'_dual_of_P3'
 
 
 lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
-    (p : (G.dual).Point) :
-    ∃ ℓ m n : (G.dual).Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n :=
+    (p : G.Point) :
+    ∃ ℓ m n : G.Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n :=
   three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') p
 
 

--- a/FiniteGeometry/ProjectivePlane.lean
+++ b/FiniteGeometry/ProjectivePlane.lean
@@ -37,7 +37,7 @@ instance dual_projective (G : IncidenceGeometry) [ProjectivePlane G] : Projectiv
   P4 := ProjectivePlane.P3
 
 namespace ProjectivePrereqs
-variable {G : IncidenceGeometry}
+variable {G : IncidenceGeometry} {A B C : G.Point} {ℓ m: G.Line}
 
 noncomputable
 def line_through {p q : G.Point} (hpq : p ≠ q) (hP1 : P1 (G:=G)) : G.Line :=
@@ -49,12 +49,7 @@ lemma line_through_unique
   let huniq := (Classical.choose_spec (hP1 hpq)).2
   exact huniq ℓ ⟨hpℓ, hqℓ⟩
 
-end ProjectivePrereqs
-
-
-namespace AlternativeAxioms
-variable {G : IncidenceGeometry}
-
+section noncollinear
 def triSet (a b c : G.Point) : Set G.Point :=
   {x | x = a ∨ x = b ∨ x = c}
 
@@ -80,6 +75,47 @@ lemma noncollinear₂₃ {A B C : G.Point} : noncollinear A B C ↔ noncollinear
 lemma noncollinear₃₁₂ {A B C : G.Point} : noncollinear C A B ↔ noncollinear A B C := by
   simp [noncollinear, triSet, collinear]
   tauto
+end noncollinear
+
+lemma noncollinear_of_witness' (hP1 : P1 (G := G)) (hAB : A ≠ B)
+    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCnotℓ : ¬ C ∈ᵢ ℓ) :
+    (∀ x : G.Line, A ∈ᵢ x → B ∈ᵢ x → ¬ C ∈ᵢ x) := by
+  intro x hAx hBx
+  suffices x = ℓ by subst x; exact hCnotℓ
+  have h₁ := line_through_unique hAB hP1 hAx hBx
+  have h₂ := (line_through_unique hAB hP1 hAℓ hBℓ).symm
+  exact h₁.trans h₂
+
+lemma noncollinear_of_witness (hP1 : P1 (G := G)) (hAB : A ≠ B) :
+    A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ ¬C ∈ᵢ ℓ → noncollinear A B C := by
+  rintro ⟨hAℓ, hBℓ, hC_not_ℓ⟩
+  simp [noncollinear, triSet, collinear]
+  exact noncollinear_of_witness' hP1 hAB hAℓ hBℓ hC_not_ℓ
+
+lemma line_eq_of_point_eq
+    (hP1 : P1 (G := G)) (hA_ne_B : A ≠ B)
+    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hBm : B ∈ᵢ m) : ℓ = m := by
+  obtain ⟨l, _, huniq⟩ := hP1 hA_ne_B
+  have hℓ : ℓ = l := huniq ℓ ⟨hAℓ, hBℓ⟩
+  have hm : m = l := huniq m ⟨hAm, hBm⟩
+  trans l
+  · exact hℓ
+  · exact hm.symm
+
+lemma not_mem_of_line_ne (hP1 : P1 (G := G)) (hAB : A ≠ B)
+    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hne : ℓ ≠ m) :
+    ¬ B ∈ᵢ m := by
+  intro hBm
+  have : ℓ = m := line_eq_of_point_eq (G := G) (hP1 := hP1) hAB hAℓ hBℓ hAm hBm
+  exact hne this
+
+end ProjectivePrereqs
+
+
+namespace AlternativeAxioms
+open ProjectivePrereqs
+variable {G : IncidenceGeometry}
+
 
 def P3' : Prop :=
   ∃ A B C D : G.Point,
@@ -97,47 +133,23 @@ def P3'' : Prop :=
 section FromP3'
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
 variable {G : IncidenceGeometry}
+variable {ℓ m : G.Line} {A B C : G.Point}
 variable (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
 
-lemma noncollinear_of_witness' {A B C : G.Point} {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B)
-    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCnotℓ : ¬ C ∈ᵢ ℓ) :
-    (∀ x : G.Line, A ∈ᵢ x → B ∈ᵢ x → ¬ C ∈ᵢ x) := by
-  intro x hAx hBx
-  suffices x = ℓ by subst x; exact hCnotℓ
-  have h₁ := line_through_unique hAB hP1 hAx hBx
-  have h₂ := (line_through_unique hAB hP1 hAℓ hBℓ).symm
-  exact h₁.trans h₂
 
-lemma noncollinear_of_witness {ℓ : G.Line} (hP1 : P1 (G := G)) (hAB : A ≠ B) :
-    A ∈ᵢ ℓ ∧ B ∈ᵢ ℓ ∧ ¬C ∈ᵢ ℓ → noncollinear A B C := by
-  rintro ⟨hAℓ, hBℓ, hC_not_ℓ⟩
-  simp [noncollinear, triSet, collinear]
-  exact noncollinear_of_witness' hP1 hAB hAℓ hBℓ hC_not_ℓ
-
-lemma line_eq_of_point_eq
-    (hP1 : P1 (G := G)) {A P : G.Point} (hA_ne_P : A ≠ P) {ℓ m : G.Line}
-    (hAℓ : A ∈ᵢ ℓ) (hPℓ : P ∈ᵢ ℓ) (hAm : A ∈ᵢ m) (hPm : P ∈ᵢ m) : ℓ = m := by
-  obtain ⟨l, _, huniq⟩ := hP1 hA_ne_P
-  have hℓ : ℓ = l := huniq ℓ ⟨hAℓ, hPℓ⟩
-  have hm : m = l := huniq m ⟨hAm, hPm⟩
-  trans l
-  · exact hℓ
-  · exact hm.symm
 
 lemma point_eq_of_incident
-    (hP2 : P2 (G := G)) {ℓ m : G.Line} (hℓm : ℓ ≠ m)
-    {P Q : G.Point} (hPℓ : P ∈ᵢ ℓ) (hPm : P ∈ᵢ m)
-    (hQℓ : Q ∈ᵢ ℓ) (hQm : Q ∈ᵢ m) : P = Q :=
-  line_eq_of_point_eq (G := G.dual) (hP1 := hP2) (A := ℓ) (P := m) (ℓ := P) (m := Q)
-    hℓm hPℓ hPm hQℓ hQm
+    (hP2 : P2 (G := G)) (hℓm : ℓ ≠ m) (hAℓ : A ∈ᵢ ℓ) (hAm : A ∈ᵢ m)
+    (hBℓ : B ∈ᵢ ℓ) (hBm : B ∈ᵢ m) : A = B :=
+  line_eq_of_point_eq (G := G.dual) (hP1 := hP2) hℓm hAℓ hAm hBℓ hBm
 
-lemma line_ne_of_noncollinear {A B C : G.Point} {ℓ₁ ℓ₂ : G.Line}
-    (hABC  : noncollinear A B C) (hAℓ₁  : A ∈ᵢ ℓ₁) (hBℓ₁ : B ∈ᵢ ℓ₁) (hCℓ₂ : C ∈ᵢ ℓ₂) : ℓ₁ ≠ ℓ₂ := by
+lemma line_ne_of_noncollinear
+    (hABC  : noncollinear A B C) (hAℓ  : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hCm : C ∈ᵢ m) : ℓ ≠ m := by
   rintro rfl
-  apply hABC; use ℓ₁; simp [collinear, triSet]
-  exact ⟨hAℓ₁, hBℓ₁, hCℓ₂⟩
+  apply hABC; use ℓ; simp [collinear, triSet]
+  exact ⟨hAℓ, hBℓ, hCm⟩
 
-lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
+lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {P Q : G.Point}
     (hABC : noncollinear A B C) (hA_ne_P : A ≠ P) {mB mC : G.Line}
     (hAmB : A ∈ᵢ mB) (hBmB : B ∈ᵢ mB) (_ : A ∈ᵢ mC) (hCmC : C ∈ᵢ mC)
     (_ : P ∈ᵢ mB) (_ : Q ∈ᵢ mC) : P ≠ Q := by
@@ -148,19 +160,19 @@ lemma points_distinct_of_noncollinear (hP1 : P1 (G := G)) {A B C P Q : G.Point}
 
 
 
-lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hPQ : P ≠ Q) (h₁ : l ≠ m) (h₂ : m ≠ n)
-    (h₃ : P ∈ᵢ l) (h₄ : P ∈ᵢ m) (h₅ : Q ∈ᵢ n) (h₆ : Q ∈ᵢ m) : noncollinear (G:= G.dual) l m n := by
-  suffices h_no_common : ¬ ∃ A : G.Point, A ∈ᵢ l ∧ A ∈ᵢ m ∧ A ∈ᵢ n by
+lemma nonconcurrent_chain (hP2 : P2 (G := G)) (hAB : A ≠ B) (h₁ : ℓ ≠ m) (h₂ : m ≠ n)
+    (h₃ : A ∈ᵢ ℓ) (h₄ : A ∈ᵢ m) (h₅ : B ∈ᵢ n) (h₆ : B ∈ᵢ m) : noncollinear (G:= G.dual) ℓ m n := by
+  suffices h_no_common : ¬ ∃ A' : G.Point, A' ∈ᵢ ℓ ∧ A' ∈ᵢ m ∧ A' ∈ᵢ n by
     simpa [noncollinear, collinear, triSet] using h_no_common
   intro ⟨A', _, _, _⟩
-  apply hPQ
-  calc P
-    _ = A' := by symm; apply point_eq_of_incident (ℓ:= l) (m:=m) (P:=A') (Q:=P) <;> assumption
-    _ = Q := by apply point_eq_of_incident (ℓ:= m) (m:=n) (P:=A') (Q:=Q) <;> assumption
+  apply hAB
+  calc A
+    _ = A' := by symm; apply point_eq_of_incident (ℓ:= ℓ) (m:=m) (A:=A') (B:=A) <;> assumption
+    _ = B := by apply point_eq_of_incident (ℓ:= m) (m:=n) (A:=A') (B:=B) <;> assumption
 
 
-lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) {A B C : G.Point} (hAB : A ≠ B)
-    {ℓ : G.Line} (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
+lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) (hAB : A ≠ B)
+    (hAℓ : A ∈ᵢ ℓ) (hBℓ : B ∈ᵢ ℓ) (hC_not_ℓ : ¬ C ∈ᵢ ℓ) : noncollinear A B C := by
   intro hCol
   simp [triSet, collinear] at hCol
   rcases hCol with ⟨m, _, _, hCm⟩
@@ -171,8 +183,8 @@ lemma noncollinear_of_line_through_AB_not_C (hP1 : P1 (G := G)) {A B C : G.Point
 
 
 
-lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
-    (ℓ : G.Line) : ∃ p q r : G.Point, p ≠ q ∧ p ≠ r ∧ q ≠ r ∧ p ∈ᵢ ℓ ∧ q ∈ᵢ ℓ ∧ r ∈ᵢ ℓ := by
+lemma three_points_on_line (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G)) (ℓ : G.Line) :
+    ∃ P Q R : G.Point, P ≠ Q ∧ P ≠ R ∧ Q ≠ R ∧ P ∈ᵢ ℓ ∧ Q ∈ᵢ ℓ ∧ R ∈ᵢ ℓ := by
   rcases hP3' with
     ⟨A,B,C,D,
      hAB,hAC,hAD,hBC,hBD,hCD,
@@ -256,10 +268,9 @@ lemma P3'_dual_of_P3'
     exact nonconcurrent_chain hP2 hCD ℓAC_ne_ℓCD ℓBD_ne_ℓCD.symm hAℓAC.2 hCℓCD.1 hBℓBD.2 hCℓCD.2
 
 
-lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G))
-    (p : G.Point) :
-    ∃ ℓ m n : G.Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ p ∈ᵢ ℓ ∧ p ∈ᵢ m ∧ p ∈ᵢ n :=
-  three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') p
+lemma three_lines_through_point (hP1 : P1 (G := G)) (hP2 : P2 (G := G)) (hP3' : P3' (G := G)) (A : G.Point) :
+  ∃ ℓ m n : G.Line, ℓ ≠ m ∧ ℓ ≠ n ∧ m ≠ n ∧ A ∈ᵢ ℓ ∧ A ∈ᵢ m ∧ A ∈ᵢ n :=
+  three_points_on_line (G := G.dual) hP2 hP1 (P3'_dual_of_P3' hP1 hP2 hP3') A
 
 
 
@@ -267,16 +278,36 @@ end FromP3'
 
 section FromP3''
 open IncidenceGeometry ProjectivePrereqs AlternativeAxioms
-variable {G : IncidenceGeometry}
+variable {G : IncidenceGeometry} {A : G.Point} {ℓ m: G.Line}
+
+lemma exists_line_with_point_and_nonpoint (hP3'' : P3'' (G := G)) : ∃ ℓ : G.Line, ∃ A B, A ∈ᵢ ℓ ∧ ¬B ∈ᵢ ℓ := by
+  rcases hP3'' with ⟨⟨A, ℓ₀, hAℓ₀⟩, hOff⟩
+  rcases hOff ℓ₀ ℓ₀ with ⟨B, hBℓ₀, _⟩
+  exact ⟨ℓ₀, A, B, hAℓ₀, hBℓ₀⟩
 
 lemma two_distinct_lines (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G)): ∃ ℓ m : G.Line, ℓ ≠ m := by
-  rcases hP3'' with ⟨⟨p₀, ℓ₀, _⟩, hOff⟩
-  rcases hOff ℓ₀ ℓ₀ with ⟨q, hqℓ₀, _⟩
-  have hpq : p₀ ≠ q := by rintro rfl; contradiction
-  rcases hP1 hpq with ⟨m, ⟨_, hqm⟩, _⟩
-  use ℓ₀, m
-  show ℓ₀ ≠ m
-  rintro rfl; contradiction
+  rcases exists_line_with_point_and_nonpoint hP3'' with ⟨ℓ, A, B, hAℓ, hBnotℓ⟩
+  have hBA : B ≠ A := point_ne_of_mem_not_mem hBnotℓ hAℓ
+  rcases hP1 hBA.symm with ⟨m, ⟨_, hBm : B ∈ᵢ m⟩, _⟩
+  use m, ℓ
+  show m ≠ ℓ
+  exact line_ne_of_mem_not_mem hBm hBnotℓ
+
+lemma exists_line_through_point_off (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G))
+    (hAℓ : A ∈ᵢ ℓ) : ∃ m : G.Line, A ∈ᵢ m ∧ m ≠ ℓ := by
+  rcases hP3''.2 ℓ ℓ with ⟨Q, hQℓ, _⟩
+  have hAQ : Q ≠ A := point_ne_of_mem_not_mem hQℓ hAℓ
+  rcases hP1 hAQ.symm with ⟨r, ⟨hAr, hQr⟩, _⟩
+  exact ⟨r, hAr, line_ne_of_mem_not_mem hQr hQℓ⟩
+
+lemma exists_third_line_through_point_off_two
+    (hP1 : P1 (G := G)) (hP3'' : P3'' (G := G))
+    (hAℓ : A ∈ᵢ ℓ) : ∃ n : G.Line, A ∈ᵢ n ∧ n ≠ ℓ ∧ n ≠ m := by
+  rcases hP3''.2 ℓ m with ⟨B, hBℓ, hBm⟩
+  have hAQ : B ≠ A := point_ne_of_mem_not_mem hBℓ hAℓ
+  rcases hP1 hAQ with ⟨n, ⟨hAn, hQn⟩, _⟩
+  refine ⟨n, hQn, ?_, ?_⟩
+  <;> apply line_ne_of_mem_not_mem hAn <;> assumption
 
 
 lemma P3'_of_P3''
@@ -284,91 +315,44 @@ lemma P3'_of_P3''
     P3' (G := G) := by
   obtain ⟨ℓ, m, hℓm⟩ := two_distinct_lines (G := G) hP1 hP3''
   obtain ⟨B, ⟨hBℓ, hBm⟩, hBuniq⟩ := hP2 hℓm
-
   rcases hP3''.2 ℓ m with ⟨A, hAℓ, hAm⟩
-  have hAB : A ≠ B := by rintro rfl; exact hAℓ hBℓ
+  have hAB : A ≠ B := point_ne_of_mem_not_mem hAℓ hBℓ
 
   obtain ⟨n, ⟨hAn, hBn⟩, huniq_n⟩ := hP1 hAB
 
-  rcases hP3''.2 n n with ⟨Q₁, hQ₁n, _⟩
-  have hAQ₁ : A ≠ Q₁ := by rintro rfl; exact hQ₁n hAn
-  obtain ⟨r, ⟨hAr, hQ₁r⟩, huniq_r⟩ := hP1 hAQ₁
-  have hr_ne_n : r ≠ n := by rintro rfl; contradiction
+  obtain ⟨r, hAr, hr_ne_n⟩ := exists_line_through_point_off (G := G) hP1 hP3'' hAn
+  obtain ⟨s, hAs, hs_ne_n, hs_ne_r⟩ := exists_third_line_through_point_off_two hP1 hP3'' hAn (m:=r)
 
-  rcases hP3''.2 n r with ⟨Q₂, hQ₂n, hQ₂r⟩
-  have hAQ₂ : A ≠ Q₂ := by rintro rfl; contradiction
-  obtain ⟨s, ⟨hAs, hQ₂s⟩, huniq_s⟩ := hP1 hAQ₂
-  have hs_ne_n : s ≠ n := by rintro rfl; contradiction
-  have hs_ne_r : s ≠ r := by rintro rfl; contradiction
+  have hr_ne_ℓ : r ≠ ℓ := line_ne_of_mem_not_mem hAr hAℓ
+  obtain ⟨C, ⟨hCr, hCℓ⟩, _⟩ := hP2 hr_ne_ℓ
 
-  have hr_ne_ℓ : r ≠ ℓ := by rintro rfl; contradiction
-  obtain ⟨C, ⟨hCr, hCℓ⟩, hCuniq⟩ := hP2 hr_ne_ℓ
+  have hs_ne_m : s ≠ m := line_ne_of_mem_not_mem hAs hAm
+  obtain ⟨D, ⟨hDs, hDm⟩, _⟩ := hP2 hs_ne_m
 
-  have hs_ne_m : s ≠ m := by rintro rfl; contradiction
-  obtain ⟨D, ⟨hDs, hDm⟩, hDuniq⟩ := hP2 hs_ne_m
+  have hAC : A ≠ C := point_ne_of_mem_not_mem hAℓ hCℓ
+  have hAD : A ≠ D := point_ne_of_mem_not_mem hAm hDm
 
-  -- basic distinctness
-  have hAC : A ≠ C := by rintro rfl; exact hAℓ hCℓ
-  have hAD : A ≠ D := by rintro rfl; exact hAm hDm
+  have hBr : ¬ B ∈ᵢ r := not_mem_of_line_ne hP1 hAB hAn hBn hAr hr_ne_n.symm
+  have hBs : ¬ B ∈ᵢ s := not_mem_of_line_ne hP1 hAB hAn hBn hAs hs_ne_n.symm
 
-  have hBr : ¬ B ∈ᵢ r := by
-    intro hB_r
-    have : r = n :=
-      line_eq_of_point_eq (G := G) (hP1 := hP1)
-        (A := A) (P := B) (ℓ := r) (m := n) hAB hAr hB_r hAn hBn
-    exact hr_ne_n this
-  have hBs : ¬ B ∈ᵢ s := by
-    intro hB_s
-    have : s = n :=
-      line_eq_of_point_eq (G := G) (hP1 := hP1)
-        (A := A) (P := B) (ℓ := s) (m := n) hAB hAs hB_s hAn hBn
-    exact hs_ne_n this
-
-  have hBC : B ≠ C := by rintro rfl; contradiction
-  have hBD : B ≠ D := by rintro rfl; contradiction
+  have hBC : B ≠ C := point_ne_of_mem_not_mem hBr hCr
+  have hBD : B ≠ D := point_ne_of_mem_not_mem hBs hDs
 
   have hCD : C ≠ D := by
     rintro rfl
     have : C = B := hBuniq C ⟨hCℓ, hDm⟩
-    subst C; contradiction
+    exact hBC this.symm
 
-  -- show C ∉ n
-  have hCnotn : ¬ C ∈ᵢ n := by
-    intro hCn
-    have : r = n :=
-      line_eq_of_point_eq (G := G) (hP1 := hP1)
-        (A := A) (P := C) (ℓ := r) (m := n) hAC hAr hCr hAn hCn
-    exact hr_ne_n this
+  have hCnotn : ¬ C ∈ᵢ n := not_mem_of_line_ne hP1 hAC hAr hCr hAn hr_ne_n
+  have hDnotn : ¬ D ∈ᵢ n := not_mem_of_line_ne hP1 hAD hAs hDs hAn hs_ne_n
+  have hDnotr : ¬ D ∈ᵢ r := not_mem_of_line_ne hP1 hAD hAs hDs hAr hs_ne_r
+  have hDnotℓ : ¬ D ∈ᵢ ℓ := not_mem_of_line_ne hP1 hBD hBm hDm hBℓ hℓm.symm
 
-  -- show D ∉ n
-  have hDnotn : ¬ D ∈ᵢ n := by
-    intro hDn
-    have : s = n :=
-      line_eq_of_point_eq (G := G) (hP1 := hP1)
-        (A := A) (P := D) (ℓ := s) (m := n) hAD hAs hDs hAn hDn
-    exact hs_ne_n this
-
-  -- show D ∉ r and D ∉ ℓ
-  have hDnotr : ¬ D ∈ᵢ r := by
-    intro hDr; apply hs_ne_r.symm
-    show r = s
-    exact
-      line_eq_of_point_eq (G := G) (hP1 := hP1)
-        (A := A) (P := D) (ℓ := r) (m := s) hAD hAr hDr hAs hDs
-  have hDnotℓ : ¬ D ∈ᵢ ℓ := by
-    intro hDℓ
-    have hDB : D = B := hBuniq D ⟨hDℓ, hDm⟩
-    subst B; contradiction
-
-  -- assemble the four noncollinearities via the helper lemma
-  have hABC : noncollinear (G := G) A B C :=
-    noncollinear_of_line_through_AB_not_C (G := G) hP1 hAB hAn hBn hCnotn
-  have hABD : noncollinear (G := G) A B D :=
-    noncollinear_of_line_through_AB_not_C (G := G) hP1 hAB hAn hBn hDnotn
-  have hACD : noncollinear (G := G) A C D := by
-    exact noncollinear_of_line_through_AB_not_C (G := G) hP1 hAC hAr hCr hDnotr
-  have hBCD : noncollinear (G := G) B C D := by
-    exact noncollinear_of_line_through_AB_not_C (G := G) hP1 hBC hBℓ hCℓ hDnotℓ
+  -- assemble noncollinearities (as you already do)
+  have hABC : noncollinear A B C := noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hCnotn
+  have hABD : noncollinear A B D := noncollinear_of_line_through_AB_not_C hP1 hAB hAn hBn hDnotn
+  have hACD : noncollinear A C D := noncollinear_of_line_through_AB_not_C hP1 hAC hAr hCr hDnotr
+  have hBCD : noncollinear B C D := noncollinear_of_line_through_AB_not_C hP1 hBC hBℓ hCℓ hDnotℓ
 
   exact
     ⟨A, B, C, D,

--- a/FiniteGeometry/Set.lean
+++ b/FiniteGeometry/Set.lean
@@ -4,34 +4,23 @@ import Mathlib.Data.Set.Insert
 namespace Set
 variable {α : Type*}
 
+-- increase heartbeats in the following lemma
+set_option maxHeartbeats 500000 in
 lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A', B', C'})
     (h₁ : A' ≠ B' ∧ A' ≠ C' ∧ B' ≠ C') : T ⊆ {A, B, C, D} → (T = {A, B, C}) ∨
     (T = {A, B, D}) ∨ (T = {A, C, D}) ∨ (T = {B, C, D}) := by
   subst T
-  obtain ⟨_, _, _⟩ := h₁
-  intro h₂
-  have := Set.subset_def.mp h₂
-  simp at this
-  rcases this with ⟨(rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl)⟩
+  intro h₂; simp [Set.subset_def] at h₂
+  -- each of A', B', C' can take any of 4 values.
+  -- we analyze each of the 64 combinations;
+  rcases h₂ with ⟨(rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl)⟩
   any_goals
     first
-    | contradiction
-    | simp
-  any_goals
-    first
+    | tauto
     | right; right; right; ext x; simp; tauto
     | right; right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · left; ext x; simp; tauto
-  · right; left; ext x; simp; tauto
-  · right; left; ext x
-    simp [or_left_comm, or_comm, or_assoc]
+    | right; left; ext x; simp; tauto
+    | left; ext x; simp; tauto
 
 
 

--- a/FiniteGeometry/Set.lean
+++ b/FiniteGeometry/Set.lean
@@ -1,0 +1,38 @@
+import Mathlib.Data.Set.Basic
+import Mathlib.Data.Set.Insert
+
+namespace Set
+variable {α : Type*}
+
+lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A', B', C'})
+    (h₁ : A' ≠ B' ∧ A' ≠ C' ∧ B' ≠ C') : T ⊆ {A, B, C, D} → (T = {A, B, C}) ∨
+    (T = {A, B, D}) ∨ (T = {A, C, D}) ∨ (T = {B, C, D}) := by
+  subst T
+  obtain ⟨_, _, _⟩ := h₁
+  intro h₂
+  have := Set.subset_def.mp h₂
+  simp at this
+  rcases this with ⟨(rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl), (rfl | rfl | rfl | rfl)⟩
+  any_goals
+    first
+    | contradiction
+    | simp
+  any_goals
+    first
+    | right; right; right; ext x; simp; tauto
+    | right; right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · left; ext x; simp; tauto
+  · right; left; ext x; simp; tauto
+  · right; left; ext x
+    simp [or_left_comm, or_comm, or_assoc]
+
+
+
+end Set

--- a/FiniteGeometry/Set.lean
+++ b/FiniteGeometry/Set.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.Set.Insert
 namespace Set
 variable {α : Type*}
 
--- increase heartbeats in the following lemma
+-- increased heartbeats in the following lemma
 set_option maxHeartbeats 500000 in
 lemma subset_four_choose_three  {A B C D A' B' C' : α} {T : Set α} (h : T = {A', B', C'})
     (h₁ : A' ≠ B' ∧ A' ≠ C' ∧ B' ≠ C') : T ⊆ {A, B, C, D} → (T = {A, B, C}) ∨


### PR DESCRIPTION
**New geometric definitions and supporting lemmas:**

* Added definitions for `collinear`, `triangle`, `generalPosition`, `concurrent`, and `quad` in incidence geometry, along with supporting lemmas such as `generalPosition_spec` and `quad_rule` for reasoning about these concepts.
* Introduced the `Subgeometry` structure and conversion to an `IncidenceGeometry`, enabling work with subgeometries and their induced incidence relations.
* Added the lemma `subset_four_choose_three` in `Set.lean` to facilitate reasoning about subsets of four elements and their three-element selections.

**Refactoring and consistency improvements:**

* Refactored the definitions of `trace` and `pencil` in `IncidenceGeometry.lean` to use sets instead of subtypes, simplifying their usage and aligning with mathematical conventions.
* Removed redundant or relocated lemmas from `IncidenceGeometryExamples.lean` and moved them to the appropriate files, improving code organization.

**Finite set utilities and combinatorics:**

* Added utility lemmas for working with finite sets, such as `mem_compl_singleton` and `card_finset_three`, and updated their usage in examples. [[1]](diffhunk://#diff-21c7f922bac33bffc742ec9ff5bc32f40fe1f9d44713141b0f90e64a0da028e8R1-R19) [[2]](diffhunk://#diff-f2e8ed059ad3144878e77f6e14dce15126d9594d6c9f83e7ae8287ccd98c915fL85-R92)
* Defined and instantiated `twoSubsets` and related `Fintype` instances for lines and points in the affine geometry example, improving clarity and correctness.

**File and import organization:**

* Added new files `FiniteGeometry/Finset.lean` and `FiniteGeometry/Set.lean` for organizing set and finset related utilities, and updated imports accordingly. [[1]](diffhunk://#diff-21c7f922bac33bffc742ec9ff5bc32f40fe1f9d44713141b0f90e64a0da028e8R1-R19) [[2]](diffhunk://#diff-61197c50ca0df61bc484ca29b8f0523d89be524ad5b65d00674c454fdb980f7eR1-R27) [[3]](diffhunk://#diff-bea0c52da43d4d344c0a77c154075de315e10db8c7d869021d252d2526856c30R7-R30)
